### PR TITLE
mediaplayer: fix wrong if/else

### DIFF
--- a/mediaplayer/mediaplayer
+++ b/mediaplayer/mediaplayer
@@ -106,9 +106,7 @@ sub playerctl {
 if ($player_arg eq '' or $player_arg eq 'mpd') {
     mpd;
 }
-elsif ($player_arg =~ /cmus$/) {
+if ($player_arg =~ /cmus$/) {
     cmus;
 }
-else {
-    playerctl;
-}
+playerctl;


### PR DESCRIPTION
There was a small error in the previous commit: if mpc executed correctly but wasn't playing anything, then the script would output a blank string -- instead of try to search for other players.