### PR TITLE
mediaplayer - readme additions

### DIFF
--- a/mediaplayer/README.md
+++ b/mediaplayer/README.md
@@ -2,9 +2,20 @@
 
 Generic media player support
 
-This displays "ARTIST - SONG" if a music is playing.
-Supported players are: spotify, vlc, audacious, xmms2, mplayer, mpd
-and others.
+This displays "ARTIST - SONG" if music is playing.
+Supported players are:
+- spotify, vlc, audacious, xmms2, mplayer and others that
+use MPRIS DBus Interface Specification
+- mpd
+- cmus
+
+mpd is supported through mpc (music player client).
+
+For MPRIS support you need to have playerctl binary in your path.
+See: https://github.com/acrisci/playerctl
+
+If you leave the instance empty it will try to find an
+active player used on it's own.
 
 ``` ini
 [mediaplayer]


### PR DESCRIPTION
- Specify in more details what is supported.
- List the requirement for playerctl for MPRIS
- Note about leaving instance empty.