### PR TITLE
Removed endline ($) to make cmus work

### DIFF
--- a/mediaplayer/mediaplayer
+++ b/mediaplayer/mediaplayer
@@ -113,7 +113,7 @@ sub playerctl {
 if ($player_arg eq '' or $player_arg eq 'mpd') {
     mpd;
 }
-if ($player_arg =~ /cmus$/) {
+if ($player_arg =~ /cmus/) {
     cmus;
 }
 playerctl;

--- a/mediaplayer/mediaplayer
+++ b/mediaplayer/mediaplayer
@@ -110,7 +110,7 @@ sub playerctl {
     print(join(" - ", @metadata)) if @metadata;
 }
 
-if ($player_arg eq '' or $player_arg eq 'mpd') {
+if ($player_arg eq '' or $player_arg =~ /mpd/) {
     mpd;
 }
 if ($player_arg =~ /cmus/) {


### PR DESCRIPTION
Because of how $player_arg is defined, there is a single quote between
$BLOCK_INSTANCE and endline ($).

```perl
$player_arg = "--player='cmus'";
```