### PR TITLE
bandwidth: explicitly tell pango to use FontAwesome

### DIFF
--- a/bandwidth/README.md
+++ b/bandwidth/README.md
@@ -9,7 +9,7 @@ i3blocks-bandwidth is an i3blocks blocklet script to monitor bandwidth usage
 The default configuration uses
 
 ```
-printf "%-5.1f/%5.1f %s/s\n", rx, wx, unit;
+printf "<span font='FontAwesome'>  </span>%-5.1f/%5.1f %s/s\n", rx, wx, unit;
 ```
 
 as the default print command. The `%-5.1f` and `%5.1f` indicate that 
@@ -37,7 +37,7 @@ Options:
     Allowed units: Kb, KB, Mb, MB, Gb, GB, Tb, TB
     Units may have optional it/its/yte/ytes on the end, e.g. Mbits, KByte
 -p  Awk command to be called after a measurement is made. 
-    Default: printf "%-5.1f/%5.1f %s/s\n", rx, wx, unit;
+    Default: printf "<span font='FontAwesome'>  </span>%-5.1f/%5.1f %s/s\n", rx, wx, unit;
     Exposed variables: rx, wx, tx, unit, iface
 -l  List available interfaces in /proc/net/dev
 -h  Show this help text

--- a/bandwidth/bandwidth
+++ b/bandwidth/bandwidth
@@ -8,7 +8,8 @@
 iface="${BLOCK_INSTANCE:-$(ip route | awk '/^default via/ {print $5; exit}')}"
 dt=3
 unit=Mb
-printf_command='printf "%-5.1f/%5.1f %s/s\n", rx, wx, unit;'
+label="<span font='FontAwesome'>  </span>" # down arrow up arrow
+printf_command="printf \"${label}%-5.1f/%5.1f %s/s\n\", rx, wx, unit;"
 
 function check_proc_net_dev {
     if [ ! -f "/proc/net/dev" ]; then
@@ -39,7 +40,7 @@ Options:
 \tAllowed units: Kb, KB, Mb, MB, Gb, GB, Tb, TB
 \tUnits may have optional it/its/yte/ytes on the end, e.g. Mbits, KByte
 -p\tAwk command to be called after a measurement is made. 
-\tDefault: printf \"%%-5.1f/%%5.1f %%s/s\\\\n\", rx, wx, unit;
+\tDefault: printf \"<span font='FontAwesome'>  </span>%%-5.1f/%%5.1f %%s/s\\\\n\", rx, wx, unit;
 \tExposed variables: rx, wx, tx, unit, iface
 -l\tList available interfaces in /proc/net/dev
 -h\tShow this help text


### PR DESCRIPTION
Fixes a bug where the up/down arrows don't display properly if your pango is up to date.