### PR TITLE
[volume-pulseaudio] Fix a bug which prevents users from setting custom icon for muted state

### DIFF
--- a/volume-pulseaudio/volume-pulseaudio
+++ b/volume-pulseaudio/volume-pulseaudio
@@ -19,7 +19,7 @@ SHORT_FORMAT=2
 USE_PERCENT=1
 USE_ALSA_NAME=0
 
-while getopts F:f:paH:M:L:T:t:C:c:h opt; do
+while getopts F:f:paH:M:L:X:T:t:C:c:h opt; do
     case "$opt" in
         F) LONG_FORMAT="$OPTARG" ;;
         f) SHORT_FORMAT="$OPTARG" ;;


### PR DESCRIPTION
[This line](https://github.com/vivien/i3blocks-contrib/blob/597a27df27/volume-pulseaudio/volume-pulseaudio#L31) is never executed because [the X was missing](https://github.com/vivien/i3blocks-contrib/pull/87/files) so I fixed it