### PR TITLE
bandwidth2: add space before byte unit, enforce all consistent widget character length

### DIFF
--- a/bandwidth2/bandwidth2.c
+++ b/bandwidth2/bandwidth2.c
@@ -84,7 +84,7 @@ void display(int const unit, double b, int const warning, int const critical)
     b = b * 8;
 
   if (b < 1024) {
-    printf("%5.1lf %c/s", b, unit);
+    printf("%5.1lf  %c/s", b, unit);
   } else if (b < 1024 * 1024) {
     printf("%5.1lf K%c/s", b / 1024, unit);
   } else if (b < 1024 * 1024 * 1024) {


### PR DESCRIPTION
"B/s" was only 3 chars long while "KB/s" and the others were 4 chars long. This would cause the block widget to change length all the time and was shifting the entire content of the i3bar back and forth which was very annoying.