### PR TITLE
volume-pulseaudio support device.description as name

### DIFF
--- a/volume-pulseaudio/README.md
+++ b/volume-pulseaudio/README.md
@@ -43,6 +43,7 @@ Options:
 -S  Subscribe to volume events (requires persistent block, always uses long format)
 -p	Omit the percent sign (%) in volume
 -a	Use ALSA name if possible
+-d	Use device.description as name
 -H	Symbol to use when audio level is high. Default: '  '
 -M	Symbol to use when audio level is medium. Default: '  '
 -L	Symbol to use when audio level is low. Default: '  '

--- a/volume-pulseaudio/i3blocks.conf
+++ b/volume-pulseaudio/i3blocks.conf
@@ -8,3 +8,9 @@ interval=persist
 command=$SCRIPT_DIR/volume-pulseaudio -a
 interval=once
 signal=1
+
+#if you prefer use device.description as name
+[volume-pulseaudio]
+command=$SCRIPT_DIR/volume-pulseaudio -dF 1
+interval=once
+signal=1

--- a/volume-pulseaudio/volume-pulseaudio
+++ b/volume-pulseaudio/volume-pulseaudio
@@ -18,16 +18,18 @@ LONG_FORMAT=0
 SHORT_FORMAT=2
 USE_PERCENT=1
 USE_ALSA_NAME=0
+USE_DESCRIPTION=0
 
 SUBSCRIBE=0
 
-while getopts F:Sf:paH:M:L:X:T:t:C:c:h opt; do
+while getopts F:Sf:padH:M:L:X:T:t:C:c:h opt; do
     case "$opt" in
         S) SUBSCRIBE=1 ;;
         F) LONG_FORMAT="$OPTARG" ;;
         f) SHORT_FORMAT="$OPTARG" ;;
         p) USE_PERCENT=0 ;;
         a) USE_ALSA_NAME=1 ;;
+        d) USE_DESCRIPTION=1 ;;
         H) AUDIO_HIGH_SYMBOL="$OPTARG" ;;
         M) AUDIO_MED_SYMBOL="$OPTARG" ;;
         L) AUDIO_LOW_SYMBOL="$OPTARG" ;;
@@ -91,9 +93,9 @@ function print_format {
 }
 
 function print_block {
-    for name in INDEX NAME VOL MUTED; do
+    for name in INDEX NAME VOL MUTED DESCRIPTION; do
         read $name
-    done < <(pacmd list-sinks | grep "index:\|name:\|volume: front\|muted:" | grep -A3 '*')
+    done < <(pacmd list-sinks | grep "index:\|name:\|volume: front\|muted:\|device.description" | grep -A4 '*')
     INDEX=$(echo "$INDEX" | grep -o '[0-9]\+')
     VOL=$(echo "$VOL" | grep -o "[0-9]*%" | head -1 )
     VOL="${VOL%?}"
@@ -110,6 +112,11 @@ grep "alsa.name\|alsa.mixer_name" |\
 head -n1 |\
 sed 's/.*= "\(.*\)".*/\1/')
         NAME=${ALSA_NAME:-$NAME}
+    fi
+
+    if [[ $USE_DESCRIPTION == 1 ]] ; then
+        DESCRIPTION=$(echo "$DESCRIPTION" | cut -d "=" -f 2 | xargs)
+        NAME=${DESCRIPTION:-$NAME}
     fi
 
     if [[ $MUTED =~ "no" ]] ; then


### PR DESCRIPTION
So basically instead of 
`  80% [6:8D_D3_AA_11_BB_CC]`
this PR support 
`  80% [6:SRS-X55]`

which i think more understandable