### PR TITLE
volume-pulseadio: add missing command in README

### DIFF
--- a/volume-pulseaudio/README.md
+++ b/volume-pulseaudio/README.md
@@ -23,7 +23,7 @@ the following to your i3 config
 # change volume or toggle mute
 bindsym XF86AudioRaiseVolume exec amixer -q -D pulse sset Master 5%+ && pkill -RTMIN+1 i3blocks 
 bindsym XF86AudioLowerVolume exec amixer -q -D pulse sset Master 5%- && pkill -RTMIN+1 i3blocks
-bindsym XF86AudioMute exec amixer -q -D pulse sset Master toggle && pkill -RTMIN+1
+bindsym XF86AudioMute exec amixer -q -D pulse sset Master toggle && pkill -RTMIN+1 i3blocks
 ```
 
 where the number `1` in `-RTMIN+1` can be replaced to another signal number,


### PR DESCRIPTION
The config changes for media keys in the volume-pulseaudio is missing a command to restart i3blocks. This adds it