### PR TITLE
example config: (cpu_usage) fix block min_width

### DIFF
--- a/config.example
+++ b/config.example
@@ -93,7 +93,7 @@ interval=5
 [cpu_usage]
 label=CPU
 interval=10
-min_width=CPU: 100.00%
+min_width=CPU 100.00%
 #separator=false
 
 [load_average]


### PR DESCRIPTION
The default block changed from `CPU: 100.00%` to `CPU 100.00%` in vivien/i3blocks@1209af4, i.e. the colon is not used in the label.

Replaces original vivien/i3blocks#222