### PR TITLE
volume: pulse-detection: explicitly try the "pulse" device

### DIFF
--- a/volume/volume
+++ b/volume/volume
@@ -23,9 +23,9 @@
 # For ALSA users, you may use "default" for your primary card
 # or you may use hw:# where # is the number of the card desired
 MIXER="default"
-if [ command -v pulseaudio >/dev/null 2>&1 && pulseaudio --check ] ; then
+if command -v pulseaudio >/dev/null 2>&1 && pulseaudio --check ; then
     # pulseaudio is running, but not all installations use "pulse"
-    if [ "$(amixer info | head -1 | cut -d ' ' -f 2)" == "pulse" ] ; then
+    if amixer -D pulse info >/dev/null 2>&1 ; then
         MIXER="pulse"
     fi
 fi


### PR DESCRIPTION
I noticed on one machine (where pulse is the right option) that it's not the default output of `amixer info` and you need to explicitly specify `-D pulse`. When this command succeeds, there is no more need to check the output.
