### PR TITLE
mediaplayer: use playerctl when no instance is specified

### DIFF
--- a/mediaplayer/README.md
+++ b/mediaplayer/README.md
@@ -17,11 +17,11 @@ use MPRIS DBus Interface Specification
 
 mpd is supported through mpc (music player client).
 
-For MPRIS support you need to have playerctl binary in your path.
+For MPRIS support you need to have the playerctl binary in your path.
 See: https://github.com/acrisci/playerctl
 
-If you leave the instance empty it will try to find an
-active player used on it's own.
+If you leave the instance empty playerctl will try to find an
+active MPRIS-compatible player on its own.
 
 # Installation
 

--- a/mediaplayer/mediaplayer
+++ b/mediaplayer/mediaplayer
@@ -15,12 +15,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# Requires playerctl binary to be in your path (except cmus)
-# See: https://github.com/acrisci/playerctl
+# For all media players except mpd/cmus/rhythmbox, MPRIS support should be
+# enabled and the playerctl binary should be in your path.
+# See https://github.com/acrisci/playerctl
 
 # Set instance=NAME in the i3blocks configuration to specify a music player
 # (playerctl will attempt to connect to org.mpris.MediaPlayer2.[NAME] on your
-# DBus session).
+# DBus session). If instance is empty, playerctl will connect to the first
+# supported media player it finds.
 
 use Time::HiRes qw(usleep);
 use Env qw(BLOCK_INSTANCE);

--- a/mediaplayer/mediaplayer
+++ b/mediaplayer/mediaplayer
@@ -140,7 +140,7 @@ sub rhythmbox {
     print($data);
 }
 
-if ($player_arg eq '' or $player_arg =~ /mpd/) {
+if ($player_arg =~ /mpd/) {
     mpd;
 }
 elsif ($player_arg =~ /cmus/) {


### PR DESCRIPTION
If no mediaplayer instance is currently specified, mpc is used as
the default metadata utility. This results in metadata failure if
mpc/mpd are not used.

This update ensures that mpc is only used when mpd is specified in the
config file, and that when no instance is specified playerctl is used.
A side-effect of this change is that any MPRIS-compatible media player
should "just work" when playerctl is installed.

Tested locally with vlc, quodlibet and audacious.