### PR TITLE
Added shutdown_menu error messages

### DIFF
--- a/shutdown_menu/shutdown_menu
+++ b/shutdown_menu/shutdown_menu
@@ -171,7 +171,10 @@ function ask_confirmation() {
   fi
 
   if [ "${confirmed}" == 0 ]; then
-    i3-msg -q "exec ${menu[${selection}]}"
+    output=$(${menu[${selection}]} 2>&1)
+    if [[ $? -ne 0 ]]; then
+      notify-send --urgency=critical "Failed to ${selection}" "$output"
+    fi
   fi
 }
 
@@ -180,6 +183,9 @@ if [[ $? -eq 0 && ! -z ${selection} ]]; then
         ${menu_confirm} =~ (^|[[:space:]])"${selection}"($|[[:space:]]) ]]; then
     ask_confirmation
   else
-    i3-msg -q "exec ${menu[${selection}]}"
+    output=$(${menu[${selection}]} 2>&1)
+    if [[ $? -ne 0 ]]; then
+      notify-send --urgency=critical "Failed to ${selection}" "$output"
+    fi
   fi
 fi


### PR DESCRIPTION
If an error occurs (such as when hibernating), a notification using 'notify-send' will alert the user.