### PR TITLE
calendar: adds support for calendar popup position top/bottom

### DIFF
--- a/calendar/README.md
+++ b/calendar/README.md
@@ -28,6 +28,7 @@ DATEFMT=+%H:%M:%S
 # SHORTFMT=+%H:%M:%S
 HEIGHT=180
 WIDTH=220
+POSITION=bottom
 ```
 
 * Add `for_window [class="Yad"] floating enable` to your i3 config file.
@@ -41,6 +42,7 @@ Parameters _[deprecated!]_:
 * `-f FMT`: date/time format (default _+%a %d.%m.%Y %H:%M:%S_)
 * `-W WIDTH`: width of the window (default _200_)
 * `-H HEIGHT`: height of the window (default _200_)
+* `-p POSITION`: position of the window (default _bottom_)
 
 Additionally you may want to
 

--- a/calendar/calendar
+++ b/calendar/calendar
@@ -4,13 +4,15 @@ WIDTH=${WIDTH:-200}
 HEIGHT=${HEIGHT:-200}
 DATEFMT=${DATEFMT:-"+%a %d.%m.%Y %H:%M:%S"}
 SHORTFMT=${SHORTFMT:-"+%H:%M:%S"}
+POSITION=${POSITION:-"bottom"} #top|bottom
 
 OPTIND=1
-while getopts ":f:W:H:" opt; do
+while getopts ":f:W:H:p:" opt; do
     case $opt in
         f) DATEFMT="$OPTARG" ;;
         W) WIDTH="$OPTARG" ;;
         H) HEIGHT="$OPTARG" ;;
+        p) POSITION="$OPTARG" ;;
         \?)
             echo "Invalid option: -$OPTARG" >&2
             exit 1
@@ -27,7 +29,11 @@ case "$BLOCK_BUTTON" in
 
 	# the position of the upper left corner of the popup
 	posX=$(($BLOCK_X - $WIDTH / 2))
-	posY=$(($BLOCK_Y - $HEIGHT))
+	if [ "$POSITION" == "bottom" ] ; then
+		posY=$(($BLOCK_Y - $HEIGHT))
+	else
+		posY=$BLOCK_Y
+	fi
 
 	i3-msg -q "exec yad --calendar \
         --width=$WIDTH --height=$HEIGHT \


### PR DESCRIPTION
I use i3bar with position top, so I needed to change this block to support popup position to be top or bottom.
I added a parameter to configure the position of the popup.