### PR TITLE
battery2: add support for colors of fontawesome icons

### DIFF
--- a/battery2/battery2
+++ b/battery2/battery2
@@ -5,14 +5,30 @@
 #
 # A battery indicator blocklet script for i3blocks
 
+# Copyright (C) 2018 Olof Sjödin <me@olofsjodin.se>
+# Edits are licensed under the GPL version 3
+#
+# Added support for colored icons.
+
+
 import re
 from subprocess import check_output
 
 status = check_output(['acpi'], universal_newlines=True)
 
+# Colors
+BATTERY_NO_FOUND_COLOR = "red"
+LIGHTNING_COLOR = "yellow"
+PLUG_COLOR = "cyan"
+BATTERY_COLOR = "cyan"
+UNKNOWN_STATUS_COLOR = "cyan"
+
+def add_color(color, body):
+    return "<span color='" + color + "'>" + body + "</span>"
+
 if not status:
     # stands for no battery found
-    fulltext = "<span color='red'><span font='FontAwesome'>\uf00d \uf240</span></span>"
+    fulltext = "<span color='" + BATTERY_NO_FOUND_COLOR + "'><span font='FontAwesome'>\uf00d \uf240</span></span>"
     percentleft = 100
 else:
     # if there is more than one battery in one laptop, the percentage left is 
@@ -48,17 +64,24 @@ else:
     else:
         percentleft = 0
 
+    
     # stands for charging
-    FA_LIGHTNING = "<span color='yellow'><span font='FontAwesome'>\uf0e7</span></span>"
+    FA_LIGHTNING = "<span color='" + LIGHTNING_COLOR + "'><span font='FontAwesome'>\uf0e7</span></span>"
 
     # stands for plugged in
     FA_PLUG = "<span font='FontAwesome'>\uf1e6</span>"
+    if "PLUG_COLOR" in locals():
+        FA_PLUG = "<span color='" + PLUG_COLOR + "'>" + FA_PLUG + "</span>"
 
     # stands for using battery
     FA_BATTERY = "<span font='FontAwesome'>\uf240</span>"
+    if "BATTERY_COLOR" in locals():
+        FA_BATTERY = "<span color='" + BATTERY_COLOR + "'>" + FA_BATTERY + "</span>"
 
     # stands for unknown status of battery
     FA_QUESTION = "<span font='FontAwesome'>\uf128</span>"
+    if "UNKNOWN_STATUS_COLOR" in locals():
+        FA_QUESTION = add_color(UNKNOWN_STATUS_COLOR, FA_QUESTION)
 
 
     if state == "Discharging":


### PR DESCRIPTION
Hi! This is my first contribution to i3blocks!

## What is new?
![i3blocks-diff](https://user-images.githubusercontent.com/1075918/40577404-418a0f20-6105-11e8-823c-cde79be4242a.png)
*(Top: Before; Below: Now)*
I've modified battery2 with support for colored font awesome icons and are searching for feedback. Note that the code I've written might be considered as "messy", but can be easily fixed if requested.

## Are there better ways to encode the colors?
![i3blocks-code](https://user-images.githubusercontent.com/1075918/40577462-45457dba-6106-11e8-9ba6-ae493148d89d.png)
As seen above, I have encoded the colors into global variables inside the code and the question is whether there are better ways to edit the colors instead of to hardcode the colors. I've read the [documentation](https://github.com/vivien/i3blocks/wiki/Writing-Your-Own-Blocklet) where it says that the script can access the user configuration input via the environment variables `BLOCK_NAME`, `BLOCK_INSTANCE` and the other three is to access mouse input (which are irrelevant to this case). The documentation doesn't say it explicitly under the Environment Variables subtitle, but I guess that the `instance=...` in each block is where you enter the value which are sent to `BLOCK_INSTANCE`? Furthermore, what is the best practise for sending more than one value? Here are two suggestion I have:
```
{'lightning_color': 'blue', 'plug_color': 'pink'}
blue,pink
```

The first one is *ugly*, but more readable than the last one. It is ugly because it doesn't look consistent with the previous configurations in i3blocks.conf. And is readable because I know which one is which without having to look in the documentation or the source code every time I want to change something.

What I want to say here is that we need better ways to send multiple values in i3blocks. Please.

Thank you for taking your time to reading about me ranting :)