### PR TITLE
arch-update: updated dependency: pacman-contrib

### DIFF
--- a/arch-update/README.md
+++ b/arch-update/README.md
@@ -10,6 +10,7 @@ Be always on top of your available updates with this blocklet. Optionally show A
 
 * Arch Linux or another arch based distro
 * python3
+* [pacman-contrib](https://www.archlinux.org/packages/?name=pacman-contrib) for `checkupdates`
 
 # Optional Dependencies
 


### PR DESCRIPTION
The `checkupdates` executable has been moved from the main pacman
package a while ago:
https://git.archlinux.org/pacman.git/commit/?id=0c99eabd50752310f42ec808c8734a338122ec86