### PR TITLE
Exit on missing default route

### DIFF
--- a/bandwidth/bandwidth
+++ b/bandwidth/bandwidth
@@ -40,6 +40,9 @@ elif [[ -z $INTERFACE ]]; then
   INTERFACE=$(ip route | awk '/^default/ { print $5 ; exit }')
 fi
 
+# Exit if there is no default route
+[[ -z "$IF" ]] && exit
+
 # Issue #36 compliant.
 if ! [ -e "/sys/class/net/${INTERFACE}/operstate" ] || \
     (! [ "$TREAT_UNKNOWN_AS_UP" = "1" ] && 

--- a/iface/iface
+++ b/iface/iface
@@ -21,6 +21,9 @@
 IF="${IFACE:-$BLOCK_INSTANCE}"
 IF="${IF:-$(ip route | awk '/^default/ { print $5 ; exit }')}"
 
+# Exit if there is no default route
+[[ -z "$IF" ]] && exit
+
 #------------------------------------------------------------------------
 
 # As per #36 -- It is transparent: e.g. if the machine has no battery or wireless


### PR DESCRIPTION
When there's no default route the scripts should exit early.  I noticed the `iface` script erroring when my network was down.

From what I can tell `iface` and `bandwidth` are affected. `bandwidth3` also uses `ip route | awk` to get the interface name but deals with it later so no change was required there.