### PR TITLE
Remove unneeded `command` line in `volume` block

### DIFF
--- a/config.example
+++ b/config.example
@@ -36,7 +36,6 @@ markup=none
 # See the script for details.
 
 [volume]
-command=$SCRIPT_DIR/volume
 #label=♪
 label=VOL
 interval=once


### PR DESCRIPTION
Already set by `command=$SCRIPT_DIR/$BLOCK_NAME` line