### PR TITLE
cpu_usage: Fixes: #191 - properly set defaults

### DIFF
--- a/cpu_usage/cpu_usage
+++ b/cpu_usage/cpu_usage
@@ -12,11 +12,11 @@ use utf8;
 use Getopt::Long;
 
 # default values
-my $t_warn = $ENV{T_WARN} || 50;
-my $t_crit = $ENV{T_CRIT} || 80;
+my $t_warn = $ENV{T_WARN} // 50;
+my $t_crit = $ENV{T_CRIT} // 80;
 my $cpu_usage = -1;
-my $decimals = $ENV{DECIMALS} || 2;
-my $label = $ENV{LABEL} || "";
+my $decimals = $ENV{DECIMALS} // 2;
+my $label = $ENV{LABEL} // "";
 
 sub help {
     print "Usage: cpu_usage [-w <warning>] [-c <critical>] [-d <decimals>]\n";


### PR DESCRIPTION
Changed the OR operation to the // default operator. This way, values can be set to 0.