### PR TITLE
volume-pulseaudio: adds tracking of running device instead of the default one

### DIFF
--- a/volume-pulseaudio/volume-pulseaudio
+++ b/volume-pulseaudio/volume-pulseaudio
@@ -118,9 +118,11 @@ function print_format {
 }
 
 function print_block {
+    ACTIVE=$(pacmd list-sinks | grep "state\: RUNNING" -B4 -A7 | grep "index:\|name:\|volume: front\|muted:")
+    [ -z "$ACTIVE" ] && ACTIVE=$(pacmd list-sinks | grep "index:\|name:\|volume: front\|muted:" | grep -A3 '*')
     for name in INDEX NAME VOL MUTED; do
         read $name
-    done < <(pacmd list-sinks | grep "index:\|name:\|volume: front\|muted:" | grep -A3 '*')
+    done < <(echo "$ACTIVE")
     INDEX=$(echo "$INDEX" | grep -o '[0-9]\+')
     VOL=$(echo "$VOL" | grep -o "[0-9]*%" | head -1 )
     VOL="${VOL%?}"


### PR DESCRIPTION
## Description

When switching devices volume-pulseaudio does not switch to the newly activated device.
As a result, it's stuck with the default device's volume, mute status etc.

That happens because volume-pulseaudio keeps track of the default device instead of the device with that has the *RUNNING* state, according to *pactl*'s output.

If no device is being used (all devices are on *SUSPENDED* state), I fall back to the default one since pactl/pacmd do not give information about which of the suspended devices is the currently used one.
Once any of them goes to *RUNNING* state though, will be picked up by the script. 

## Proposed fix
This pull request fixes this issue by grepping for the device that's on *RUNNING* state and falling back to the previous solution when all devices are suspended.
I have tested this with my bluetooth headset and several other output devices.
