### PR TITLE
volume: Use '/usr/bin/env bash' as shebang

### DIFF
--- a/volume/volume
+++ b/volume/volume
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (C) 2014 Julien Bonjean <julien@bonjean.info>
 # Copyright (C) 2014 Alexander Keller <github@nycroth.com>
 


### PR DESCRIPTION
On some systems (e.g. NixOS, openBSD) Bash isn't located or symlinked at
`/bin/bash`. This change ensures that the correct path is used across
different operating systems.