### PR TITLE
wifi: echo red "down" when interface exists but inactive

### DIFF
--- a/wifi/wifi
+++ b/wifi/wifi
@@ -22,8 +22,15 @@ fi
 
 # As per #36 -- It is transparent: e.g. if the machine has no battery or wireless
 # connection (think desktop), the corresponding block should not be displayed.
-[[ ! -d /sys/class/net/${INTERFACE}/wireless ]] ||
-    [[ "$(cat /sys/class/net/$INTERFACE/operstate)" = 'down' ]] && exit
+[[ ! -d /sys/class/net/${INTERFACE}/wireless ]] && exit
+
+# If the wifi interface exists but no connection is active, "down" shall be displayed.
+if [[ "$(cat /sys/class/net/$INTERFACE/operstate)" = 'down' ]]; then
+    echo "down"
+    echo "down"
+    echo "#FF0000"
+    exit
+fi
 
 #------------------------------------------------------------------------
 


### PR DESCRIPTION
The current `wifi` script does not show "wifi down" when the wifi device i.e. interface exists but is not active, which is a common situation on a laptop. Besides, this pull request makes the behavior of `wifi` script consistent with `iface` script.