### PR TITLE
Remove `label` from list of valid properties

### DIFF
--- a/config.example
+++ b/config.example
@@ -11,7 +11,6 @@
 # full_text
 # instance
 # interval
-# label
 # min_width
 # name
 # separator


### PR DESCRIPTION
After vivien/i3blocks@61646f2, this is no longer valid