### PR TITLE
volume-pulseaudio: move only to available sinks

### DIFF
--- a/volume-pulseaudio/volume-pulseaudio
+++ b/volume-pulseaudio/volume-pulseaudio
@@ -94,13 +94,20 @@ function move_sinks_to_new_default {
     done
 }
 
+function list_available_sinks {
+    # finding all sinks with at least one port not having available: no
+    pacmd list-sinks | grep -Poz "(^|\n).*index: (.|\n)+?(?=\n.*index|$)" \
+      | grep -Pz 'available: (?!no)' | sed 's/\x00//'
+}
+
 function set_default_playback_device_next {
     inc=${1:-1}
-    num_devices=$(pacmd list-sinks | grep -c index:)
     sink_arr=($(pacmd list-sinks | grep index: | grep -o '[0-9]\+'))
-    default_sink_index=$(( $(pacmd list-sinks | grep index: | grep -no '*' | grep -o '^[0-9]\+') - 1 ))
-    default_sink_index=$(( ($default_sink_index + $num_devices + $inc) % $num_devices ))
-    default_sink=${sink_arr[$default_sink_index]}
+    sink_arr=($(list_available_sinks | grep -Pzo '(?<=index: )[0-9]*\n'))
+    num_devices=${#sink_arr[@]}
+    default_sink_index=$(( $(list_available_sinks | grep index: | grep -no '*' | grep -o '^[0-9]\+') - 1 ))
+    default_sink_index_next=$(( ($default_sink_index + $num_devices + $inc) % $num_devices ))
+    default_sink=${sink_arr[$default_sink_index_next]}
     pacmd set-default-sink $default_sink
     move_sinks_to_new_default $default_sink
 }


### PR DESCRIPTION
Hey,
at some point clicking the block to switch to other sinks stopped working for me.
It turns out that (at least in my distri) pacmd silently refuses to switch to a sink which has no port available (=> only available: no). As the default just does not change, it will stay on the same sink all the time as it will only attempt to switch to the same (not available sink) on every further click.

I have changed the set_default_playback_device_next to only enumerate sinks which have at least one port on available on yes or unknown (or rather not "no"). For this to happen some more multiline-grep-magic was required to filter out the unavailable ones.

Cheers, Andrej