### PR TITLE
Turn off format-truncation-warning

### DIFF
--- a/bandwidth2/Makefile
+++ b/bandwidth2/Makefile
@@ -1,6 +1,6 @@
 P=bandwidth2
 OBJECTS=
-CFLAGS=-g -Wall -Werror -O2 -std=c11
+CFLAGS=-g -Wall -Werror -O2 -std=c11 -Wno-format-truncation
 LDLIBS=
 
 $(P): $(OBJECTS)


### PR DESCRIPTION
 Line 97 gives a format-truncation-warning:
snprintf(fmtstr, sizeof (fmtstr), "%%%d.1lf ", divisor > 1000 ? 6 : 5);

Changed makefile to be able to compile.