### PR TITLE
Change shebang to conform to /usr/bin/env

### DIFF
--- a/bandwidth/bandwidth
+++ b/bandwidth/bandwidth
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (C) 2012 Stefan Breunig <stefan+measure-net-speed@mathphys.fsk.uni-heidelberg.de>
 # Copyright (C) 2014 kaueraal
 # Copyright (C) 2015 Thiago Perrotta <perrotta dot thiago at poli dot ufrj dot br>

--- a/battery/battery
+++ b/battery/battery
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Copyright 2014 Pierre Mavro <deimos@deimos.fr>
 # Copyright 2014 Vivien Didelot <vivien@didelot.org>

--- a/calendar/calendar
+++ b/calendar/calendar
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/usr/bin/env bash
 
 WIDTH=${WIDTH:-200}
 HEIGHT=${HEIGHT:-200}

--- a/cpu_usage/cpu_usage
+++ b/cpu_usage/cpu_usage
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Copyright 2014 Pierre Mavro <deimos@deimos.fr>
 # Copyright 2014 Vivien Didelot <vivien@didelot.org>

--- a/disk/disk
+++ b/disk/disk
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Copyright (C) 2014 Julien Bonjean <julien@bonjean.info>
 
 # This program is free software: you can redistribute it and/or modify

--- a/docker/docker
+++ b/docker/docker
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Number of docker containers running
 count=$(docker ps -q | wc -l | sed -r 's/^0$//g')

--- a/essid/essid
+++ b/essid/essid
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (C) 2018 borgified <borgified@gmail.com>
 # Copyright (C) 2014 Alexander Keller <github@nycroth.com>
 

--- a/gpu-load/gpu-load
+++ b/gpu-load/gpu-load
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/iface/iface
+++ b/iface/iface
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (C) 2014 Julien Bonjean <julien@bonjean.info>
 # Copyright (C) 2014 Alexander Keller <github@nycroth.com>
 

--- a/kubernetes/kubernetes
+++ b/kubernetes/kubernetes
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 KCONTEXT=$(kubectl config current-context 2>/dev/null)
 if [[ $?=="0" ]]; then
     CC=$(kubectl config view -ojsonpath='{..current-context}')

--- a/load_average/load_average
+++ b/load_average/load_average
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 # Copyright (C) 2014 Julien Bonjean <julien@bonjean.info>
 
 # This program is free software: you can redistribute it and/or modify

--- a/memory/memory
+++ b/memory/memory
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Copyright (C) 2014 Julien Bonjean <julien@bonjean.info>
 
 # This program is free software: you can redistribute it and/or modify

--- a/nm-vpn/nm-vpn
+++ b/nm-vpn/nm-vpn
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 nmcli -t connection show --active | awk -F ':' '
 /tun0/{vpn="ON"} /vpn/{name=$1}
 END{if(vpn) printf("%s\n%s\n%s\n", name, vpn, "#00FF00")}'

--- a/rofi-calendar/rofi-calendar
+++ b/rofi-calendar/rofi-calendar
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/urs/bin/env bash
 
 DATEFTM="${DATEFTM:-+%a. %d. %b. %Y}"
 SHORTFMT="${SHORTFMT:-+%d.%m.%Y}"

--- a/tahoe-lafs/tahoe-lafs
+++ b/tahoe-lafs/tahoe-lafs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 NODE_URL=${BLOCK_INSTANCE%/}
 DISK_AVAIL=$(curl -s "$NODE_URL/statistics?t=json" 2>/dev/null| jq -r '.stats."storage_server.disk_avail"')

--- a/volume-pulseaudio/volume-pulseaudio
+++ b/volume-pulseaudio/volume-pulseaudio
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Displays the default device, volume, and mute status for i3blocks
 
 set -a

--- a/wifi/wifi
+++ b/wifi/wifi
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (C) 2014 Alexander Keller <github@nycroth.com>
 
 # This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
I'm having problems using `i3blocks-contrib` in NixOS and i would like to continue using it.
This changes should ensures that the correct path is used.
It should also works for openBSD users.