### PR TITLE
mediaplayer: Bug fixes (gray forground & no Output)

### DIFF
--- a/mediaplayer/mediaplayer
+++ b/mediaplayer/mediaplayer
@@ -102,6 +102,7 @@ sub cmus {
 
             # metadata found so we are done
             print(join ' - ', @metadata);
+            print("\n");
             exit 0;
         }
     }

--- a/mediaplayer/mediaplayer
+++ b/mediaplayer/mediaplayer
@@ -40,15 +40,15 @@ sub buttons {
 
     if($method eq 'mpd') {
         if ($ENV{'BLOCK_BUTTON'} == 1) {
-            system("mpc prev");
+            system("mpc prev &>/dev/null");
         } elsif ($ENV{'BLOCK_BUTTON'} == 2) {
-            system("mpc toggle");
+            system("mpc toggle &>/dev/null");
         } elsif ($ENV{'BLOCK_BUTTON'} == 3) {
-            system("mpc next");
+            system("mpc next &>/dev/null");
         } elsif ($ENV{'BLOCK_BUTTON'} == 4) {
-            system("mpc volume +10");
+            system("mpc volume +10 &>/dev/null");
         } elsif ($ENV{'BLOCK_BUTTON'} == 5) {
-            system("mpc volume -10");
+            system("mpc volume -10 &>/dev/null");
         }
     } elsif ($method eq 'cmus') {
         if ($ENV{'BLOCK_BUTTON'} == 1) {


### PR DESCRIPTION
**Gray forground**
The used mpd comands write in stdout, i3blocks interpetes this as a gray foreground.
91560b9
Fixes: #232

**No Output**
Script didn't output `\n`
75888b4
Fixes: #234 