### PR TITLE
wifi: Add QUIET variable to wifi blocket

### DIFF
--- a/wifi/README.md
+++ b/wifi/README.md
@@ -2,6 +2,7 @@
 
 Show the strength of your wifi connection.
 If no instance is specified, wlan0 is used.
+If $QUIET is set to true, supress the output rather than displaying "down"
 
 ![](wifi.png)
 
@@ -12,5 +13,6 @@ If no instance is specified, wlan0 is used.
 command=$SCRIPT_DIR/wifi
 label=wifi:
 #INTERFACE=wlan0
+#QUIET=true
 interval=60
 ```

--- a/wifi/i3blocks.conf
+++ b/wifi/i3blocks.conf
@@ -2,4 +2,5 @@
 command=$SCRIPT_DIR/wifi
 label=wifi:
 #INTERFACE=wlan0
+#QUIET=true
 interval=60

--- a/wifi/wifi
+++ b/wifi/wifi
@@ -18,6 +18,9 @@
 if [[ -z "$INTERFACE" ]] ; then
     INTERFACE="${BLOCK_INSTANCE:-wlan0}"
 fi
+if [[ -z "$QUIET" ]] ; then
+    QUIET="${QUIET:-false}"
+fi
 #------------------------------------------------------------------------
 
 # As per #36 -- It is transparent: e.g. if the machine has no battery or wireless
@@ -26,9 +29,12 @@ fi
 
 # If the wifi interface exists but no connection is active, "down" shall be displayed.
 if [[ "$(cat /sys/class/net/$INTERFACE/operstate)" = 'down' ]]; then
-    echo "down"
-    echo "down"
-    echo "#FF0000"
+    # ... Unless the QUIET variable was set to true.
+    if [ "$QUIET" != true ]; then
+        echo "down"
+        echo "down"
+        echo "#FF0000"
+    fi
     exit
 fi
 


### PR DESCRIPTION
Add an environment variable $QUIET to the wifi blocket which when set to true will suppress the output if the interface is down. This is useful if you only want to show the blocket when connected to a Wi-Fi network, and not while connected over ethernet or other networks.