### PR TITLE
usb: fix output from `lsblk` command

### DIFF
--- a/usb/usb
+++ b/usb/usb
@@ -101,7 +101,7 @@ def getLeafDevicePaths():
     return lines
 
 def getKernelName(path):
-    return check_output(['lsblk', '-ndso', 'KNAME', path],
+    return check_output(['lsblk', '-ndo', 'KNAME', path],
             universal_newlines=True).rstrip("\n")
 
 def getDeviceType(path):
@@ -357,7 +357,7 @@ def setParsedArgs(args):
 
 parseArguments()
 leaves = getLeafDevicePaths()
-leaves = [path for path in leaves if not fastIgnore(path)]
+leaves = [path for path in leaves if not fastIgnore(path) and "└─" not in path]
 attributeMaps = getAttributeMaps(leaves)
 leaves = (path for path in leaves if not ignore(path, attributeMaps[path]))
 outputs = filter(None, map(getOutput, leaves))


### PR DESCRIPTION
On my Arch machine, when getLeafDevicePaths() was calling `lsblk -spndo
NAME', it was returning lines with an unusual character that was being
included into the list of paths. I changed the final filter to the
'leaves' and added a check for that.

Also, getKernelName(path), on my machine, was getting duplicate lines
and partition paths from `lsblk -ndso KNAME` and that was messing up the
output for some reason. Removing the '-s' flag fixed it.