### PR TITLE
[arch-update] Add ability to set any aur helper and yay as default

### DIFF
--- a/arch-update/README.md
+++ b/arch-update/README.md
@@ -1,6 +1,6 @@
 # arch-update
 
-Be always on top of your available updates with this blocklet. Optionally show AUR updates with the help of yaourt. Colorize the outputs for if your system is up to date or you got available updates.
+Be always on top of your available updates with this blocklet. Optionally show AUR updates with the help of an AUR helper. Colorize the outputs for if your system is up to date or you got available updates.
 
 ![](screenshot.png)
 
@@ -14,7 +14,7 @@ Be always on top of your available updates with this blocklet. Optionally show A
 
 # Optional Dependencies
 
-* yaourt for aur updates
+* an aur helper for aur updates (must support `-Qua`)
 * fontawesome for awesome labels
 
 # Installation
@@ -41,6 +41,8 @@ WATCH=^linux.* ^pacman.*
 BASE_COLOR=#5fff5f
 UPDATE_COLOR=#FFFF85
 AUR=true
+AUR_HELPER=yay
+AUR_PREFIX=
 LABEL= 
 ```
 # Configuration
@@ -50,5 +52,7 @@ _Use the environment variables above instead of these deprecated command line op
 - `-w`/`--watch`: Explicitly watch for specified packages. Listed elements are treated as regular expressions for matching.
 - `-b`/`--base_color`: set the base color of the output (when your system is up to date)
 - `-u`/`--updates_available_color`: set the color of the output when updates are available
-- `-a`/`--aur`: activate AUR update support  
+- `-a`/`--aur`: activate AUR update support
+- `-t`/`--aur_helper`: specify an AUR helper to use (must support `-Qua`)
+- `-p`/`--aur_prefix`: prefix of lines to count when -Qua displays packages other than AUR
 For the latest options call `$SCRIPT_DIR/arch-update -h`.

--- a/arch-update/arch-update
+++ b/arch-update/arch-update
@@ -39,8 +39,20 @@ def create_argparse():
         '--aur',
         action = 'store_const',
         const = True,
-        default = _default('AUR', 'False', strbool),
-        help='Include AUR packages. Attn: Yaourt must be installed'
+        default = _default('AUR', '', strbool),
+        help='Include AUR packages.'
+    )
+    parser.add_argument(
+        '-t',
+        '--aur_helper',
+        default = _default('AUR_HELPER', 'yay'),
+        help='Specify an AUR helper to use. Must support -Qua'
+    )
+    parser.add_argument(
+        '-p',
+        '--aur_prefix',
+        default = _default('AUR_PREFIX', ''),
+        help='Prefix of lines to count when -Qua displays packages other than AUR'
     )
     parser.add_argument(
         '-q',
@@ -67,7 +79,7 @@ def get_updates():
         return []
 
     updates = [line.split(' ')[0]
-               for line in output.split('\n')
+               for line in output.strip().split('\n')
                if line]
 
     return updates
@@ -76,9 +88,9 @@ def get_updates():
 def get_aur_updates():
     output = ''
     try:
-        output = check_output(['yaourt', '-Qua']).decode('utf-8')
+        output = check_output([args.aur_helper, '-Qua']).decode('utf-8')
     except subprocess.CalledProcessError as exc:
-        # yaourt exits with 1 and no output if no updates are available.
+        # helper may exit with code 1 and no output if no updates are available.
         # we ignore this case and go on
         if not (exc.returncode == 1 and not exc.output):
             raise exc
@@ -86,8 +98,8 @@ def get_aur_updates():
         return []
 
     aur_updates = [line.split(' ')[0]
-                   for line in output.split('\n')
-                   if line.startswith('aur/')]
+                   for line in output.strip().split('\n')
+                   if line.startswith(args.aur_prefix)]
 
     return aur_updates
 


### PR DESCRIPTION
This additionally replaces yaourt with yay as the default. I think that's reasonable since yay is quite popular and yaourt is a persona non grata in arch (gone from the wiki and the AUR).

Please note that yaourt can still be used:
```
AUR_HELPER=yaourt
AUR_PREFIX=aur/
```