### PR TITLE
Fix broken output for mediaplayer

### DIFF
--- a/mediaplayer/mediaplayer
+++ b/mediaplayer/mediaplayer
@@ -123,11 +123,13 @@ sub playerctl {
     chomp $artist;
     # exit status will be nonzero when playerctl cannot find your player
     exit(0) if $? || $artist eq '(null)';
-
+    $artist =~ s/^\s+|\s+$//g ;
+    
     push(@metadata, $artist) if $artist;
 
     my $title = qx(playerctl $player_arg metadata title);
     exit(0) if $? || $title eq '(null)';
+    $title  =~ s/^\s+|\s+$//g ;
 
     push(@metadata, $title) if $title;
 


### PR DESCRIPTION
there was an endline char after artist resulting in only the artist name displayed