### PR TITLE
Update arch-update for change of checkupdates

### DIFF
--- a/arch-update/arch-update
+++ b/arch-update/arch-update
@@ -62,7 +62,14 @@ def create_argparse():
 
 
 def get_updates():
-    output = check_output(['checkupdates']).decode('utf-8')
+    output = ''
+    try:
+        output = check_output(['checkupdates']).decode('utf-8')
+    except subprocess.CalledProcessError as exc:
+        # checkupdates exits with 1 and no output if no updates are available.
+        # we ignore this case and go on
+        if not (exc.returncode == 1 and not exc.output):
+            raise exc
     if not output:
         return []
 


### PR DESCRIPTION
It seems like that `checkupdates` will exit 1 if there is no update available, causing unexpected behavior of this script.
I revised it a little bit and it works fine now.