### PR TITLE
iface: Fix shebang to use `/usr/bin/env` rather than `/bin/bash`

### DIFF
--- a/iface/iface
+++ b/iface/iface
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (C) 2014 Julien Bonjean <julien@bonjean.info>
 # Copyright (C) 2014 Alexander Keller <github@nycroth.com>
 


### PR DESCRIPTION
This helps in shells where `bash` isn't present at `/bin/bash`

I use NixOS and `/bin/bash` does not work. Using the `env` and mentioning the interpreter is how it should be done to prevent issues.