### PR TITLE
 aur-update: enable caching of updates list

### DIFF
--- a/aur-update/README.md
+++ b/aur-update/README.md
@@ -16,10 +16,15 @@ interval=43200
 UPDATE_COLOR=red
 QUIET=1
 IGNORE=root vidyodesktop
+#CACHE_UPDATES=0
+#CACHE_PATH=/tmp/i3_blocks_aur-update_list.txt
 ```
 
 Right or middle click sends a notification (via notify-send) with a list of outdated packages
 and the corresponding version information.
+If you enable caching (`CACHE_UPDATES=1`), the update list will be written to a file
+(given by `CACHE_PATH`). This will be read on a click to directly show the notification
+without the delay caused by updating the list.
 
 
 ## Dependencies

--- a/aur-update/aur-update
+++ b/aur-update/aur-update
@@ -101,7 +101,7 @@ elif not args.quiet:
     print('AUR up to date')
 
 if block_button in [2, 3]:
-    sp.call(['notify-send', 'AUR updates', '\n'.join(updates)])
+    sp.call(['notify-send', 'AUR updates', '\n'.join(updates) or 'up to date'])
 
 if not 'BLOCK_NAME' in os.environ and n_updates > 0:
     # not called by i3blocks: show the complete list

--- a/aur-update/aur-update
+++ b/aur-update/aur-update
@@ -41,6 +41,8 @@ args = Args()
 args.add_argument('UPDATE_COLOR', 'yellow')
 args.add_argument('QUIET', False, bool)
 args.add_argument('IGNORE', [], list)
+args.add_argument('CACHE_UPDATES', False, bool)
+args.add_argument('CACHE_PATH', '/tmp/i3_blocks_aur-update_list.txt')
 
 
 def version_in_aur(pkg):
@@ -74,6 +76,15 @@ def vcs_version(pkg, ver):
     return None
 
 
+# show the list of updates already cached
+if args.cache_updates and block_button in [2, 3]:
+    try:
+        with open(args.cache_path, 'r') as f:
+            updates = f.read()
+    except FileNotFoundError:
+        updates = 'no updates cached'
+    sp.call(['notify-send', 'AUR updates', updates or 'up to date'])
+
 # get list of foreign packages -- assumed to be from the AUR
 packages = sp.check_output(['pacman', '-Qm']).decode('utf8')
 
@@ -100,7 +111,13 @@ if n_updates > 0:
 elif not args.quiet:
     print('AUR up to date')
 
-if block_button in [2, 3]:
+# cache the new updates list
+if args.cache_updates:
+    with open(args.cache_path, 'w') as f:
+        f.write('\n'.join(updates))
+
+# if you don't use caching, show the new list of updates
+if not args.cache_updates and block_button in [2, 3]:
     sp.call(['notify-send', 'AUR updates', '\n'.join(updates) or 'up to date'])
 
 if not 'BLOCK_NAME' in os.environ and n_updates > 0:


### PR DESCRIPTION
If you enable caching (`CACHE_UPDATES=1`), the update list will be written to a file
(given by `CACHE_PATH`). This will be read on a click to directly show the notification
without the delay caused by updating the list.