### PR TITLE
batterybar: Handle 'Not charging'

### DIFF
--- a/batterybar/batterybar
+++ b/batterybar/batterybar
@@ -25,7 +25,7 @@ battery_count=${#output[@]}
 for line in "${output[@]}";
 do
     percentages+=($(echo "$line" | grep -o -m1 '[0-9]\{1,3\}%' | tr -d '%'))
-    statuses+=($(echo "$line" | egrep -o -m1 'Discharging|Charging|AC|Full|Unknown'))
+    statuses+="$(echo "$line" | egrep -o -m1 'Discharging|Charging|AC|Full|Unknown|Not\ charging')"
     remaining=$(echo "$line" | egrep -o -m1 '[0-9][0-9]:[0-9][0-9]')
     if [[ -n $remaining ]]; then
         remainings+=(" ($remaining)")
@@ -96,7 +96,7 @@ do
     "Charging")
         color="$charging_color"
     ;;
-    "Full")
+    "Full"|"Not charging")
         color="$full_color"
     ;;
     "AC")


### PR DESCRIPTION
`acpi battery` sometimes returns 'Not charging', instead of 'Full'.
Treat them as equals.

The egrep line needs to be enclosed in `""` because bash otherwise treats "Not" and "charging" as two separate array entries.