### PR TITLE
arch-update: handle non-zero exit code of checkupdates

### DIFF
--- a/arch-update/arch-update
+++ b/arch-update/arch-update
@@ -62,7 +62,14 @@ def create_argparse():
 
 
 def get_updates():
-    output = check_output(['checkupdates']).decode('utf-8')
+    output = ''
+    try:
+        output = check_output(['checkupdates']).decode('utf-8')
+    except subprocess.CalledProcessError as exc:
+        # usually this means no updates are available
+        if not (exc.returncode == 1 and not exc.output):
+            raise exc
+
     if not output:
         return []
 

--- a/arch-update/arch-update
+++ b/arch-update/arch-update
@@ -67,7 +67,8 @@ def get_updates():
         output = check_output(['checkupdates']).decode('utf-8')
     except subprocess.CalledProcessError as exc:
         # usually this means no updates are available
-        if not (exc.returncode == 1 and not exc.output):
+        # checkupdates 1.2 returns 1 on on updates, 1.3 returns 2
+        if exc.returncode != 1 and exc.returncode != 2:
             raise exc
 
     if not output:


### PR DESCRIPTION
checkupdates v1.2.0 exits with exit code 1 when there are no updates.
In that case the script should not fail but report "system up to date".