### PR TITLE
HTMLEncoding Mediaplayer Information

### DIFF
--- a/mediaplayer/mediaplayer
+++ b/mediaplayer/mediaplayer
@@ -24,6 +24,7 @@
 
 use Time::HiRes qw(usleep);
 use Env qw(BLOCK_INSTANCE);
+use HTML::Entities;
 
 use constant DELAY => 50; # Delay in ms to let network-based players (spotify) reflect new data.
 use constant SPOTIFY_STR => 'spotify';
@@ -92,8 +93,8 @@ sub cmus {
                 my $key = shift @data;
                 my $value = join ' ', @data;
 
-                @metadata[0] = $value if $key eq 'artist';
-                @metadata[1] = $value if $key eq 'title';
+                @metadata[0] = encode_entities($value) if $key eq 'artist';
+                @metadata[1] = encode_entities($value) if $key eq 'title';
             }
         }
 
@@ -111,7 +112,7 @@ sub mpd {
     my $data = qx(mpc current);
     if (not $data eq '') {
         buttons("mpd");
-        print($data);
+        print(encode_entities($data));
         exit 0;
     }
 }
@@ -124,12 +125,12 @@ sub playerctl {
     # exit status will be nonzero when playerctl cannot find your player
     exit(0) if $? || $artist eq '(null)';
 
-    push(@metadata, $artist) if $artist;
+    push(@metadata, encode_entities($artist)) if $artist;
 
     my $title = qx(playerctl $player_arg metadata title);
     exit(0) if $? || $title eq '(null)';
 
-    push(@metadata, $title) if $title;
+    push(@metadata, encode_entities($title)) if $title;
 
     print(join(" - ", @metadata)) if @metadata;
 }
@@ -138,7 +139,7 @@ sub rhythmbox {
     buttons('rhythmbox');
 
     my $data = qx(rhythmbox-client --print-playing --no-start);
-    print($data);
+    print(encode_entities($data));
 }
 
 if ($player_arg eq '' or $player_arg =~ /mpd/) {


### PR DESCRIPTION
Song or artist names with any HTML characters don't get displayed properly. HTMLEncoding them so they actually get displayed. 