### PR TITLE
Fix extra newline

### DIFF
--- a/mediaplayer/mediaplayer
+++ b/mediaplayer/mediaplayer
@@ -123,7 +123,7 @@ sub playerctl {
     chomp $artist;
     # exit status will be nonzero when playerctl cannot find your player
     exit(0) if $? || $artist eq '(null)';
-
+    chomp($artist) if $artist;
     push(@metadata, $artist) if $artist;
 
     my $title = qx(playerctl $player_arg metadata title);


### PR DESCRIPTION
Fixes bug I found when attempting to use the mediaplayer blocklet.
Remove extra newline returned by playerctl artist metatdata that was preventing track title from showing by default