### PR TITLE
New block: ssid:  SSID of current wifi connection

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -21,7 +21,7 @@ This repository contains a set of scripts (a.k.a. *blocklets*) for link:https://
 | link:disk-io[] | Monitor disk reads and writes
 | link:docker[] | Show the number of Docker containers and container IP
 | link:email[] | Show the number of unread IMAP messages
-| link:essid[] | Show the wifi ESSID you are connected to
+| link:essid[] | Show the wifi ESSID you are connected to (dep: iwconfig, perl)
 | link:gpu-load[] | Shows load of Nvidia GPUs
 | link:iface[] | Show network interface IP/status
 | link:kbdd_layout[] | Show the keyboard layout using dbus and kbdd
@@ -39,6 +39,7 @@ This repository contains a set of scripts (a.k.a. *blocklets*) for link:https://
 | link:tahoe-lafs[] | Show status of your tahoe-lafs grid
 | link:temperature[] | Show system temperatures using lm-sensors
 | link:time[] | Show the current date/time and click to change timezones
+| link:ssid[] | Show the wifi SSID you are connected to (dep: iw, awk)
 | link:usb[] | Show connected usb storage device info
 | link:volume[] | Show the current system volume (default)
 | link:volume-pulseaudio[] | Pretty print system volume for pulseaudio

--- a/ssid/README.md
+++ b/ssid/README.md
@@ -1,0 +1,13 @@
+# ssid
+
+Show the SSID of the current wifi connection.
+If no instance is specified, wlan0 is used.
+
+# Config
+
+```
+[ssid]
+command=$SCRIPT_DIR/ssid
+#INTERFACE=wlan0
+interval=60
+```

--- a/ssid/README.md
+++ b/ssid/README.md
@@ -3,6 +3,8 @@
 Show the SSID of the current wifi connection.
 If no instance is specified, wlan0 is used.
 
+Dependencies: `iw`
+
 # Config
 
 ```

--- a/ssid/i3blocks.conf
+++ b/ssid/i3blocks.conf
@@ -1,0 +1,4 @@
+[ssid]
+command=$SCRIPT_DIR/ssid
+#INTERFACE=wlan0
+interval=60

--- a/ssid/ssid
+++ b/ssid/ssid
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Copyright (C) 2014 Alexander Keller <github@nycroth.com>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#------------------------------------------------------------------------
+if [[ -z "$INTERFACE" ]] ; then
+    INTERFACE="${BLOCK_INSTANCE:-wlan0}"
+fi
+#------------------------------------------------------------------------
+
+# As per #36 -- It is transparent: e.g. if the machine has no battery or wireless
+# connection (think desktop), the corresponding block should not be displayed.
+# Similarly, if the wifi interface exists but no connection is active, show
+# nothing
+[[ ! -d /sys/class/net/"${INTERFACE}"/wireless || \
+    "$(cat /sys/class/net/"$INTERFACE"/operstate)" = 'down' ]] && exit
+
+#------------------------------------------------------------------------
+
+SSID=$(iw "$INTERFACE" info | awk '/ssid/ {print $2}')
+
+#------------------------------------------------------------------------
+
+echo "$SSID" # full text
+echo "$SSID" # short text
+echo "#00FF00" # color

--- a/ssid/ssid
+++ b/ssid/ssid
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Copyright (C) 2020 hseg <gesh@gesh.uni.cx>
 # Copyright (C) 2014 Alexander Keller <github@nycroth.com>
 
 # This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
Based on `iface` script. Uses `iw` instead of `iwconfig`, which is deprecated
according to <https://wireless.wiki.kernel.org/en/users/documentation/iw>.
As well, avoids the perl dependency, though that's not much of a benefit.