### PR TITLE
nm-vpn: use interface type for status, add colors, add INIT status.

### DIFF
--- a/nm-vpn/README.md
+++ b/nm-vpn/README.md
@@ -15,23 +15,32 @@ Parses output from `nmcli` to show the current connected VPN name/status
 
 # Usage
 
-`nm-vpn` gets active connection info from `nmcli` for interface `tun0`.
-A VPN connection in NetworkManager is established only when `tun0` is
-active, thus the blocklet’s response time depends on how long it takes
-to connect.
+`nm-vpn` gets active connection info from `nmcli`, looks for interface type `tun`, `tap`, `vpn`. A VPN connection is treated as established only when `tun`|`tap` is present, when it's not and a `vpn` connection is listed as active it is treated as initializing.
+
+# Tunables
+
+`init_color` - color used for marking a connection in initializing state, default is '#FFFF00'
+
+`on_color` - color used for marking a connection in established state, default is '#00FF00'
 
 ## Output
 
-When `tun0` is active, `nm-vpn` will print in the following form:
-  - Full: `VPN: "Name"`
+When `tun`|`tap` is active, `nm-vpn` will print in the following form:
+  - Full: `VPN Name`
   - Short: `ON`
+  - Color will be set to `on_color` value
 
-In addition, each form will be coloured green (“\#00FF00”).
+When `tun`|`tap` in not active, `nm-vpn` will print in the following form:
+  - Full: `VPN Name`
+  - Short: `INIT`
+  - Color will be set to `init_color` value
 
 # Config
 
 ``` ini
 [nm-vpn]
-label=VPN:
+#init_color=#FFFF00
+#on_color=#00FF00
+label=VPN: 
 interval=5
 ```

--- a/nm-vpn/i3blocks.conf
+++ b/nm-vpn/i3blocks.conf
@@ -1,5 +1,7 @@
 [nm-vpn]
-label=VPN:
+#init_color=#FFFF00
+#on_color=#00FF00
+label=VPN: 
 interval=5
 
 # vim: syntax=dosini

--- a/nm-vpn/nm-vpn
+++ b/nm-vpn/nm-vpn
@@ -1,4 +1,19 @@
 #!/bin/sh
+init_color=${init_color:-#FFFF00}
+on_color=${on_color:-#00FF00}
+export init_color on_color
 nmcli -t connection show --active | awk -F ':' '
-/tun0/{vpn="ON"} /vpn/{name=$1}
-END{if(vpn) printf("%s\n%s\n%s\n", name, vpn, "#00FF00")}'
+BEGIN {
+    init_color=ENVIRON["init_color"]
+    on_color=ENVIRON["on_color"]
+}
+/vpn/{
+    name=$1
+    status="INIT"
+    color=init_color
+}
+/(tun|tap)/{
+    status="ON"
+    color=on_color
+}
+END{if(status) printf("%s\n%s\n%s\n", name, status, color)}'

--- a/nm-vpn/nm-vpn
+++ b/nm-vpn/nm-vpn
@@ -7,13 +7,13 @@ BEGIN {
     init_color=ENVIRON["init_color"]
     on_color=ENVIRON["on_color"]
 }
-/vpn/{
+$3=="vpn" {
     name=$1
     status="INIT"
     color=init_color
 }
-/(tun|tap)/{
+$3=="tun" || ($4~/^tap/ || $3~/^tap/) {
     status="ON"
     color=on_color
 }
-END{if(status) printf("%s\n%s\n%s\n", name, status, color)}'
+END {if(status) printf("%s\n%s\n%s\n", name, status, color)}'


### PR DESCRIPTION
1. Fixes: #305. Look for interface type of tap|tun instead of name for connection status determination.

2. Add injected properties for init and established state colors.

3. Update README.md and i3blocks.conf according to 2.