### PR TITLE
volume-pulseaudio: fix volume when hsp/hfp mode on

### DIFF
--- a/volume-pulseaudio/volume-pulseaudio
+++ b/volume-pulseaudio/volume-pulseaudio
@@ -118,8 +118,8 @@ function print_format {
 }
 
 function print_block {
-    ACTIVE=$(pacmd list-sinks | grep "state\: RUNNING" -B4 -A7 | grep "index:\|name:\|volume: front\|muted:")
-    [ -z "$ACTIVE" ] && ACTIVE=$(pacmd list-sinks | grep "index:\|name:\|volume: front\|muted:" | grep -A3 '*')
+    ACTIVE=$(pacmd list-sinks | grep "state\: RUNNING" -B4 -A7 | grep "index:\|name:\|volume: \(front\|mono\)\|muted:")
+    [ -z "$ACTIVE" ] && ACTIVE=$(pacmd list-sinks | grep "index:\|name:\|volume: \(front\|mono\)\|muted:" | grep -A3 '*')
     for name in INDEX NAME VOL MUTED; do
         read $name
     done < <(echo "$ACTIVE")


### PR DESCRIPTION
When using headset in hsp/hfp currently volume-pulseaudio fails to parse volume correctly because of 'front' part of the regex match.

- Fixed parsing of volume