### PR TITLE
Add global Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+PREFIX = $(HOME)/.local/
+
+_INSTALLDIR = $(DESTDIR)$(PREFIX)/libexec/i3blocks/
+
+_MAKEBLOCKS := $(dir $(wildcard */Makefile))
+all: build
+build: $(_MAKEBLOCKS)
+$(_MAKEBLOCKS):
+		$(MAKE) -C $@ 
+
+install: all do-install
+
+installdirs: 
+		install -d $(_INSTALLDIR)
+
+_BLOCKS := $(shell find . -type f -executable -not -path './.*')
+
+do-install: installdirs $(_BLOCKS)
+$(_BLOCKS):
+		install -m755 $@ $(_INSTALLDIR)
+
+uninstall:
+		rm -f $(foreach block,$(_BLOCKS),$(_INSTALLDIR)$(notdir $(block)))
+
+.PHONY: $(_MAKEBLOCKS) $(_BLOCKS) build do-install all install uninstall


### PR DESCRIPTION
`make` executes Makefies in subdirectories.
`make install` does same as `make` and installs all executables under libexec directory (`$PREFIX/libexec/i3blocks/`), default PREFIX=/home/ai/.local/.
`make uninstall` removes installed executables, but not the directory itself.

This is a subject for discussion, both on how it does the job and whether it is required here at all. Note that before starting to write it I had vague ideas on how to do it and zero practice, so someone with experience and understanding may be required to review it. 

It does the job though. Currently (46ccb08) bandwidth2 fails to build (#236 supposedly fixes this), so for 'install' target '-k' flag is required: `make -k install`, or call the `do-install` target which does not depend on `build` one. 

This Makefile should handle any new blocks without changes to it required if they either are executable scripts or have a dedicated Makefile inside their directory.