### PR TITLE
time: Enable time/time to print its output in UTF8

### DIFF
--- a/time/time
+++ b/time/time
@@ -55,6 +55,7 @@ if (!exists $display_map{$ENV{TZ}}) {
 }
 $tz_display = $display_map{$ENV{TZ}};
 
+binmode(STDOUT, ":utf8");
 my $time = strftime($format, localtime());
 if ($tz_display eq "") {
     print "$time\n";


### PR DESCRIPTION
This fixes i3 bar parsing errors when the output contains characters not
in the US-ASCII encoding space like the ä in the German März (March).

Perl will by default print in US-ASCII/Latin-1 encoding, where
especially the latter can contain characters that are not valid in UTF8.
If that happens, this will cause the entire parsing of the i3blocks
output to fail in i3 bar and cause it to only show an error message.