### PR TITLE
iface/bandwidth: fix display when using VPN

### DIFF
--- a/bandwidth/bandwidth
+++ b/bandwidth/bandwidth
@@ -37,7 +37,7 @@ done
 if [[ -z $INTERFACE ]] && [[ -n $BLOCK_INSTANCE ]]; then
   INTERFACE=$BLOCK_INSTANCE
 elif [[ -z $INTERFACE ]]; then
-  INTERFACE=$(ip route | awk '/^default/ { print $5 ; exit }')
+  INTERFACE=$(ip route | sed -e 's/^\(\S* \).*\(dev\)/\1\2/' | awk '/^default/ { print $3 ; exit }')
 fi
 
 # Exit if there is no default route

--- a/iface/iface
+++ b/iface/iface
@@ -19,7 +19,7 @@
 
 # Use the provided interface, otherwise the device used for the default route.
 IF="${IFACE:-$BLOCK_INSTANCE}"
-IF="${IF:-$(ip route | awk '/^default/ { print $5 ; exit }')}"
+IF="${IF:-$(ip route | sed -e 's/^\(\S* \).*\(dev\)/\1\2/' | awk '/^default/ { print $3 ; exit }')}"
 
 # Exit if there is no default route
 [[ -z "$IF" ]] && exit


### PR DESCRIPTION
The scripts rely on "ip route" output of the format
  default via IP dev INTERFACE ...
However, when using VPNs the output may be
  default dev INTERFACE ...

The additional sed command removes everything between "default" and
"dev" in order to fix this issue.