### PR TITLE
backlight, truncate brightness to be an integer

### DIFF
--- a/backlight/backlight
+++ b/backlight/backlight
@@ -37,5 +37,5 @@ case $BLOCK_BUTTON in
 esac
 
 
-BRIGHTNESS=$(xbacklight -get)
+BRIGHTNESS=$(xbacklight -get | cut -d . -f 1)  
 echo "${BRIGHTNESS}%"


### PR DESCRIPTION
The displayed brightness can be 10.033003. There is no need for such precision. A simple `cut` allow to truncate it to an integer.