### PR TITLE
Fix command path and explain command property

### DIFF
--- a/config.example
+++ b/config.example
@@ -24,8 +24,9 @@
 #
 # The top properties below are applied to every block, but can be overridden.
 # Each block command defaults to the script name to avoid boilerplate.
-# Change $SCRIPT_DIR to the location of your scripts!
-command=$SCRIPT_DIR/$BLOCK_NAME
+# Change $SCRIPT_DIR to the location of your scripts! (see https://github.com/vivien/i3blocks-contrib/wiki/FAQ#blocklets-refer-to-script_dir-what-does-that-mean-how-can-i-use-it)
+# actuall command will include name of block as directory and than same name as script name
+command=$SCRIPT_DIR/$BLOCK_NAME/$BLOCK_NAME
 separator_block_width=15
 markup=none
 


### PR DESCRIPTION
Fixed path for command. By default when following documentation on https://vivien.github.io/i3blocks/ there are commands in directories. This was missing in example script.
Added some clarification for `$SCRIPT_DIR` thing. Also made another pull request to clarify this in documentation. See https://github.com/vivien/i3blocks/pull/421