### PR TITLE
memory: include shared memory usage (follow htop memory usage calculation)

### DIFF
--- a/memory/memory
+++ b/memory/memory
@@ -29,6 +29,12 @@ awk -v type=$TYPE '
 /^Cached:/ {
 	mem_free+=$2
 }
+/^SReclaimable:/ {
+	mem_free+=$2
+}
+/^Shmem:/ {
+	mem_free-=$2
+}
 /^SwapTotal:/ {
 	swap_total=$2
 }


### PR DESCRIPTION
The current memory blocklet counts shared memory as cached memory. This leads to the blocklet reporting a lower memory usage than expected (by up to 40% on my laptop). This new addition follows the memory usage calculation by htop (see the htop developer here: 
https://stackoverflow.com/questions/41224738/how-to-calculate-system-memory-usage-from-proc-meminfo-like-htop), where:

Non cache/buffer memory = `MemTotal` - `MemFree` - `Buffers` - `Cached` - `SReclaimable` + `Shmem`