### PR TITLE
gpu-load: support AMD based card

### DIFF
--- a/gpu-load/README.md
+++ b/gpu-load/README.md
@@ -1,6 +1,6 @@
 # gpu-load
 
-Shows load of Nvidia GPUs.
+Shows load of Nvidia or AMD GPUs.
 
 ![](gpu-load.png)
 
@@ -8,14 +8,17 @@ The four values are the load of the:
 
 1. The GPU it self
 2. The load of the VRAM of the Card
-3. Video buffer
-4. PCIe bus utilization
+3. Video buffer (NVIDIA only)
+4. PCIe bus utilization (NVIDIA only)
 
 `short_text` only shows the GPU load.
 
 # Dependencies
 
+Choose one depends on your GPU.
+
 * `nvidia-settings` Note that on Debian-based systems, you have to add `contrib` and `non-free` to your `sources.list` in order to install the package via your package manager.
+* [`radeontop`](https://github.com/clbr/radeontop)
 
 # Config
 ```
@@ -24,6 +27,7 @@ command=$SCRIPT_DIR/gpu-load
 label=GPU
 interval=10
 #min_width=GPU 100% 100% 100% 100%
+#GPU_BRAND=NVIDIA // or AMD
 #T_WARN=70
 #T_CRIT=90
 ```

--- a/gpu-load/gpu-load
+++ b/gpu-load/gpu-load
@@ -21,10 +21,13 @@ use Getopt::Long;
 # default values
 my $t_warn = $ENV{T_WARN} || 70;
 my $t_crit = $ENV{T_CRIT} || 90;
+my $gpu_brand = $ENV{GPU_BRAND} || "NVIDIA";
 my $gpu_usage = -1;
 my $gpu_mem = -1;
 my $gpu_video = -1;
 my $gpu_pcie = -1;
+
+my $full_text = "";
 
 sub help {
     print "Usage: gpu-load [-w <warning>] [-c <critical>]\n";
@@ -38,22 +41,39 @@ GetOptions("help|h" => \&help,
            "c=i"    => \$t_crit);
 
 # Get GPU usage from nvidia-settings
-open (NVS, 'nvidia-settings -q GPUUtilization -t |') or die;
-while (<NVS>) {
-    if (/^[a-zA-Z]*=(\d+), [a-zA-Z]*=(\d+), [a-zA-Z]*=(\d+), [a-zA-Z]*=(\d+)$/) {
-        $gpu_usage = $1;
-	$gpu_mem = $2;
-	$gpu_video = $3;
-	$gpu_pcie = $4;
-        last;
+if ($gpu_brand eq "NVIDIA") {
+    open (NVS, 'nvidia-settings -q GPUUtilization -t |') or die;
+    while (<NVS>) {
+        if (/^[a-zA-Z]*=(\d+), [a-zA-Z]*=(\d+), [a-zA-Z]*=(\d+), [a-zA-Z]*=(\d+)$/) {
+            $gpu_usage = $1;
+            $gpu_mem = $2;
+            $gpu_video = $3;
+            $gpu_pcie = $4;
+            last;
+        }
     }
+    close(NVS);
+    $full_text = sprintf "%.0f%% %.0f%% %.0f%% %.0f%%\n", $gpu_usage, $gpu_mem, $gpu_video, $gpu_pcie;
+} 
+
+# For AMD, get from radeontop
+elsif ($gpu_brand eq "AMD") {
+    open (AMD, 'radeontop -d - -l 1 |') or die;
+    while (<AMD>) {
+        if (/^.*[gpu] (\d+)\.\d+%.*.*[vram] (\d+)\.\d+%.*$/) {
+            $gpu_usage = $1;
+            $gpu_mem = $2;
+            last;
+        }
+    }
+    close(AMD);
+    $full_text = sprintf "%.0f%% %.0f%%\n", $gpu_usage, $gpu_mem;
 }
-close(NVS);
 
 $gpu_usage eq -1 and die 'Can\'t find GPU information';
 
 # Print full_text, short_text
-printf "%.0f%% %.0f%% %.0f%% %.0f%%\n", $gpu_usage, $gpu_mem, $gpu_video, $gpu_pcie;
+print $full_text;
 printf "%.0f%%\n", $gpu_usage;
 
 # Print color, if needed


### PR DESCRIPTION
This add support for showing AMD based card with `radeontop` dependency.

Note that it only support 2 of 4 existing metrics because `radeontop` doesn't expose the same variable as `nvidia-settings`.

![image](https://user-images.githubusercontent.com/6151302/83697264-babbe480-a628-11ea-8ece-0b59dc000de4.png)
