### PR TITLE
mediaplayer: redirect playerctl stderr to /dev/null

### DIFF
--- a/mediaplayer/mediaplayer
+++ b/mediaplayer/mediaplayer
@@ -119,7 +119,7 @@ sub mpd {
 sub playerctl {
     buttons('playerctl');
 
-    my $artist = qx(playerctl $player_arg metadata artist);
+    my $artist = qx(playerctl $player_arg metadata artist 2>/dev/null);
     chomp $artist;
     # exit status will be nonzero when playerctl cannot find your player
     exit(0) if $? || $artist eq '(null)';


### PR DESCRIPTION
A small PR to redirect playerctl's stderr to /dev/null. My reason for suggesting this change is that my desktop manager was flooding my logs with messages like this:

```
/usr/lib/gdm-x-session: No players found
```

Confusingly, it turns out that if no player is active, playerctl will write "No players found" to *stderr*, and not *stdout*. Since the mediaplayer blocklet does not capture playerctl's stderr, this gets bubbled up to gdm with no indication that the source of the error is playerctl -> mediaplayer blocklet -> i3blocks. Afaik, this change to mediaplayer does not impact functionality, as redirecting stderr does not change playerctl's return code (and the mediaplayer blocklet doesn't look at playerctl's stderr anyway).

On another note, is there any interest in a more systematic solution to this (for all blocklets)? e.g. should I open an issue in i3blocks to suggest that we capture blocklet stderr and preface messages with "i3blocks: \<blocklet name\>: ..."?