### PR TITLE
iface: output wifi name if possible

### DIFF
--- a/batterybar/batterybar
+++ b/batterybar/batterybar
@@ -22,13 +22,16 @@
 readarray -t output <<< $(acpi battery)
 battery_count=${#output[@]}
 
+set -euo pipefail
+#set -x
+
 for line in "${output[@]}";
 do
     percentages+=($(echo "$line" | grep -o -m1 '[0-9]\{1,3\}%' | tr -d '%'))
     statuses+=($(echo "$line" | egrep -o -m1 'Discharging|Charging|AC|Full|Unknown'))
-    remaining=$(echo "$line" | egrep -o -m1 '[0-9][0-9]:[0-9][0-9]')
-    if [[ -n $remaining ]]; then
-        remainings+=(" ($remaining)")
+    remainings=$(echo "$line" | egrep -o -m1 '[0-9][0-9]:[0-9][0-9]')
+    if [[ -n $remainings ]]; then
+        remainings+=(" ($remainings)")
     else 
         remainings+=("")
     fi
@@ -126,13 +129,15 @@ do
     ;;
     esac
 
+    message=
+
     # Print Battery number if there is more than one
-    if (( $end > 0 )) ; then 
+    if (( $end > 0 )) ; then
         message="$message $(($i + 1)):"
     fi
 
     # Print extended info if clicked
-    if [[ "$BLOCK_BUTTON" -eq 1 ]]; then 
+    if [[ ! -z "${BLOCK_BUTTON+x}" && $BLOCK_BUTTON -eq 1 ]]; then
         message="$message ${statuses[$i]} <span foreground=\"$color\">${percentages[$i]}%${remainings[i]}</span>"
     fi
 

--- a/batterybar/batterybar
+++ b/batterybar/batterybar
@@ -34,7 +34,7 @@ do
     fi
 done
 
-squares="■"
+symbol="■"
 
 #There are 8 colors that reflect the current battery percentage when 
 #discharging
@@ -44,6 +44,7 @@ dis_colors=("${C1:-#FF0027}" "${C2:-#FF3B05}" "${C3:-#FFB923}"
 charging_color="${CHARGING_COLOR:-#00AFE3}"
 full_color="${FULL_COLOR:-#FFFFFF}"
 ac_color="${AC_COLOR:-#535353}"
+inactive_color="${INACTIVE_COLOR:-#333333}"
 
 
 while getopts 1:2:3:4:5:6:7:8:c:f:a:h opt; do
@@ -76,20 +77,22 @@ done
 end=$(($battery_count - 1))
 for i in $(seq 0 $end);
 do
-    if (( percentages[$i] > 0 && percentages[$i] < 20  )); then
-        squares="■"
-    elif (( percentages[$i] >= 20 && percentages[$i] < 40 )); then
-        squares="■■"
-    elif (( percentages[$i] >= 40 && percentages[$i] < 60 )); then
-        squares="■■■"
-    elif (( percentages[$i] >= 60 && percentages[$i] < 80 )); then
-        squares="■■■■"
-    elif (( percentages[$i] >=80 )); then
-        squares="■■■■■"
-    fi
+    max_num_squares=5
+    num_active_squares=$((percentages[$i]/(100/$max_num_squares) + 1))
 
+    active_squares=
+    for activeSquare in $(seq 1 $num_active_squares); do
+        active_squares="${active_squares}${symbol}"
+    done
+
+    inactive_squares=
+    for inactiveSquare in $(seq $((num_active_squares+1)) $max_num_squares); do
+        inactive_squares="${inactive_squares}${symbol}"
+    done
+
+    unknown_status=
     if [[ "${statuses[$i]}" = "Unknown" ]]; then
-        squares="<sup>?</sup>$squares"
+        unknown_status="<sup>?</sup>"
     fi
 
     case "${statuses[$i]}" in
@@ -125,13 +128,16 @@ do
 
     # Print Battery number if there is more than one
     if (( $end > 0 )) ; then 
-        message="$message $(($i + 1)):" 
+        message="$message $(($i + 1)):"
     fi
 
+    # Print extended info if clicked
     if [[ "$BLOCK_BUTTON" -eq 1 ]]; then 
         message="$message ${statuses[$i]} <span foreground=\"$color\">${percentages[$i]}%${remainings[i]}</span>"
     fi
-        message="$message <span foreground=\"$color\">$squares</span>" 
+
+    message="$message $unknown_status<span foreground=\"$color\">$active_squares</span>"
+    message="$message<span foreground=\"$inactive_color\">$inactive_squares</span>"
 done
 
 echo $message

--- a/iface/iface
+++ b/iface/iface
@@ -43,16 +43,16 @@ for flag in "$1" "$2"; do
       AF=inet6 ;;
     -L)
       if [[ "$IF" = "" ]]; then
-        LABEL="iface "
+        LABEL="iface"
       else
-        LABEL="$IF: "
+        LABEL="$IF:"
       fi ;;
   esac
 done
 
 if [[ "$IF" = "" ]] || [[ "$(cat /sys/class/net/$IF/operstate)" = 'down' ]]; then
-  echo "${LABEL}down" # full text
-  echo "${LABEL}down" # short text
+  echo "${LABEL} down" # full text
+  echo "${LABEL} down" # short text
   echo \#FF0000 # color
   exit
 fi
@@ -64,7 +64,21 @@ case $BLOCK_BUTTON in
   3) echo -n "$IPADDR" | xclip -q -se c ;;
 esac
 
+# try to guess the wifi name
+if command -v iw > /dev/null && iw $IF info > /dev/null 2>&1;
+then
+    WIFI_NAME=$(iw $IF info | grep -Po '(?<=ssid ).*' | tr -d " \t\n\r")
+
+    if [[ $BLOCK_BUTTON -eq 1 ]];
+    then
+        message="$LABEL $WIFI_NAME ($IPADDR)"
+    else
+        message="$LABEL $WIFI_NAME"
+    fi
+else
+    message="$LABEL $IPADDR"
+fi
+
 #------------------------------------------------------------------------
 
-echo "$LABEL$IPADDR" # full text
-echo "$LABEL$IPADDR" # short text
+echo "$message"


### PR DESCRIPTION
Open for discussions

1) If iw is present on the system, it will try to find the wifi name and display that as short text. As long text the IP and the wifi name will be shown.
2) I removed the spaces after the label. This aligns with all other blocks. I.e. that you don't have to set LABEL=mywifi<space>