### PR TITLE
iface: output wifi name if possible

### DIFF
--- a/iface/iface
+++ b/iface/iface
@@ -43,16 +43,16 @@ for flag in "$1" "$2"; do
       AF=inet6 ;;
     -L)
       if [[ "$IF" = "" ]]; then
-        LABEL="iface "
+        LABEL="iface"
       else
-        LABEL="$IF: "
+        LABEL="$IF:"
       fi ;;
   esac
 done
 
 if [[ "$IF" = "" ]] || [[ "$(cat /sys/class/net/$IF/operstate)" = 'down' ]]; then
-  echo "${LABEL}down" # full text
-  echo "${LABEL}down" # short text
+  echo "${LABEL} down" # full text
+  echo "${LABEL} down" # short text
   echo \#FF0000 # color
   exit
 fi
@@ -64,7 +64,21 @@ case $BLOCK_BUTTON in
   3) echo -n "$IPADDR" | xclip -q -se c ;;
 esac
 
+# try to guess the wifi name
+if command -v iw > /dev/null && iw $IF info > /dev/null 2>&1;
+then
+    WIFI_NAME=$(iw $IF info | grep -Po '(?<=ssid ).*' | tr -d " \t\n\r")
+
+    if [[ $BLOCK_BUTTON -eq 1 ]];
+    then
+        message="$LABEL $WIFI_NAME ($IPADDR)"
+    else
+        message="$LABEL $WIFI_NAME"
+    fi
+else
+    message="$LABEL $IPADDR"
+fi
+
 #------------------------------------------------------------------------
 
-echo "$LABEL$IPADDR" # full text
-echo "$LABEL$IPADDR" # short text
+echo "$message"


### PR DESCRIPTION
If iw is present on the system, it will try to find the wifi name and display that as short text.
As long text the IP and the wifi name will be shown.
I removed the spaces after the label. This aligns with all other blocks.
I.e. that you don't have to set LABEL=mywifi<space>