### PR TITLE
aur-update: cache updates via environment rather than a file

### DIFF
--- a/aur-update/README.md
+++ b/aur-update/README.md
@@ -12,19 +12,18 @@ Example i3blocks configuration:
 [aur-update]
 command=$SCRIPT_DIR/aur-update
 markup=pango
+format=json
 interval=43200
 UPDATE_COLOR=red
 QUIET=1
 IGNORE=root vidyodesktop
 #CACHE_UPDATES=0
-#CACHE_PATH=/tmp/i3_blocks_aur-update_list.txt
 ```
 
 Right or middle click sends a notification (via notify-send) with a list of outdated packages
 and the corresponding version information.
-If you enable caching (`CACHE_UPDATES=1`), the update list will be written to a file
-(given by `CACHE_PATH`). This will be read on a click to directly show the notification
-without the delay caused by updating the list.
+If you enable caching (`CACHE_UPDATES=1`), the update list will be cached as an environment variable.
+This will be read on a (right/middle) click to directly show the notification without the delay caused by updating the list.
 
 
 ## Dependencies

--- a/aur-update/aur-update
+++ b/aur-update/aur-update
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import json
 import os
 import requests
 import subprocess as sp
@@ -42,7 +43,6 @@ args.add_argument('UPDATE_COLOR', 'yellow')
 args.add_argument('QUIET', False, bool)
 args.add_argument('IGNORE', [], list)
 args.add_argument('CACHE_UPDATES', False, bool)
-args.add_argument('CACHE_PATH', '/tmp/i3_blocks_aur-update_list.txt')
 
 
 def version_in_aur(pkg):
@@ -78,10 +78,9 @@ def vcs_version(pkg, ver):
 
 # show the list of updates already cached
 if args.cache_updates and block_button in [2, 3]:
-    try:
-        with open(args.cache_path, 'r') as f:
-            updates = f.read()
-    except FileNotFoundError:
+    if '_update_cache' in os.environ:
+        updates = os.environ['_update_cache']
+    else:
         updates = 'no updates cached'
     sp.call(['notify-send', 'AUR updates', updates or 'up to date'])
 
@@ -104,17 +103,21 @@ for pkg in installed_version.keys():
     if vcs_version(pkg, v_aur) != vcs_version(pkg, v_inst):
         updates.append(pkg + ' (%s -> %s)' % (v_inst, v_aur))
 
+# create the message for the block
 n_updates = len(updates)
 if n_updates > 0:
-    msg = "<span color='{0}'>{1} AUR updates</span>"
-    print(msg.format(args.update_color, n_updates))
+    msg = "<span color='{0}'>{1} AUR updates</span>".format(args.update_color, n_updates)
 elif not args.quiet:
-    print('AUR up to date')
+    msg = 'AUR up to date'
+
+# turn it into a json message
+msg = {'full_text': msg}
 
 # cache the new updates list
 if args.cache_updates:
-    with open(args.cache_path, 'w') as f:
-        f.write('\n'.join(updates))
+    msg['_update_cache'] = '\n'.join(updates)
+
+print(json.dumps(msg))
 
 # if you don't use caching, show the new list of updates
 if not args.cache_updates and block_button in [2, 3]:


### PR DESCRIPTION
More elegant solution that does not require to write a temporary file.
Needs json format, though.