### PR TITLE
add configure script

### DIFF
--- a/configure
+++ b/configure
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -ex
+PREFIX=$(echo $1 | cut -d= -f 2)
+if [ -n "$PREFIX" ]
+then
+    sed -i "s;^PREFIX.*;PREFIX = $PREFIX;g" Makefile
+fi


### PR DESCRIPTION
since the repo already can be built with something reassembling GNU autotools convention
```
make
make install
```

this patch aims at making it even more compatible by allowing this:
```
configure --prefix=/some/path
make
make install
```

The script doesn't do more than patching the Makefile to respect the set prefix and is **fully backwards compatible** (running `./configure` without `--prefix` is a noop).