### PR TITLE
timer_and_stopwatch: add UNIX_TIME parameter to fix fullscreen use

### DIFF
--- a/timer_and_stopwatch/README.md
+++ b/timer_and_stopwatch/README.md
@@ -25,4 +25,5 @@ interval=1
 #PLAY_LABEL=(playing)
 #PAUSE_LABEL=(paused)
 #TIMER_LOOP=true
+#UNIX_TIME=true
 ```

--- a/timer_and_stopwatch/timer_and_stopwatch
+++ b/timer_and_stopwatch/timer_and_stopwatch
@@ -8,6 +8,7 @@ DEFAULT_TIMER=${DEFAULT_TIMER:-60}
 PLAY_LABEL=${PLAY_LABEL:-(playing)}
 PAUSE_LABEL=${PAUSE_LABEL:-(paused)}
 TIMER_LOOP=${TIMER_LOOP:-false}
+UNIX_TIME=${UNIX_TIME:-false}
 ###### Default environment variables ######
 
 ###### Functions ######
@@ -40,6 +41,7 @@ reset_times() {
 }
 
 set_mode() {
+  previous_unix_time=-1
   case ${modes[$mode]} in
     'timer' )
       running=false
@@ -131,7 +133,23 @@ esac
 ###### Click processing ######
 
 ###### Time increment ######
-$running && time=$(( time + incr ))
+if [[ $UNIX_TIME == true ]]; then
+  current_unix_time=$(date +%s)
+fi
+if [[ $running == true ]]; then
+  if [[ $UNIX_TIME == true ]]; then
+    if (( previous_unix_time > 0 )); then
+      incr=$(( current_unix_time - previous_unix_time ))
+    else
+      incr=1
+    fi
+    [[ ${modes[$mode]} == timer ]] && incr=$((-incr))
+  fi
+  time=$(( time + incr ))
+fi
+if [[ $UNIX_TIME == true ]]; then
+  previous_unix_time=$current_unix_time
+fi
 if (( mode == 0 )); then
   if (( time <= 0 )); then
     bgcolor='#FF0000'
@@ -158,6 +176,7 @@ cat << EOF
 "status_symbol":"$status_symbol",\
 "time":"$time",\
 "initial_time":"$initial_time",\
+"previous_unix_time":"$previous_unix_time",\
 "incr":"$incr",\
 "running":"$running",\
 "mode":"$mode",\


### PR DESCRIPTION
When LibreOffice Impress runs in presentation mode (press `F5`), the timer/stopwatch is _not_ updated. The timer/stopwatch is updated when using full screen mode in i3, such as Firefox and terminal.

This PR relates to [#255](https://github.com/vivien/i3blocks/issues/255) in i3blocks (not i3blocks-contrib). I tried to find the cause of the issue but I admit I didn't know where to look (i3blocks? LibreOffice?). For this reason, I've added this as a config parameter to allow enabling/disabling rather than pushing for a bug fix.

This PR adds a UNIX_TIME parameter to the config. When enabled, unix time is used to calculate the time difference for incrementing the timer/stopwatch. The idea is that if the `timer_and_stopwatch` script is not run every second, say for 10 seconds because LibreOffice Impress is in presentation mode, then the next time the script runs the difference in unix time is 10 seconds, which is used for incrementing the timer/stopwatch. I've tested it and it works for me.

`UNIX_TIME` defaults to false, but can be enabled with `UNIX_TIME=true` in the config.

What are your thoughts?