### PR TITLE
timer_and_stopwatch: export neutral background color

### DIFF
--- a/timer_and_stopwatch/README.md
+++ b/timer_and_stopwatch/README.md
@@ -1,8 +1,8 @@
 # timer_and_stopwatch
 
-Have a minimal timer and stopwatch blocklet. Right click to switches between
-the two functionalities, left click to start/stop the counter, wheel to set the
-timer or the initialial stopwatch time.
+A minimal timer and stopwatch blocklet. Right click switches between the two
+functionalities, left click starts/stops the counter, wheel sets the timer
+or the initialial stopwatch time.
 
 ![](running_timer.png)
 
@@ -25,4 +25,5 @@ interval=1
 #PLAY_LABEL=(playing)
 #PAUSE_LABEL=(paused)
 #TIMER_LOOP=true
+#NEUTRAL_COLOR=#000000
 ```

--- a/timer_and_stopwatch/timer_and_stopwatch
+++ b/timer_and_stopwatch/timer_and_stopwatch
@@ -8,6 +8,7 @@ DEFAULT_TIMER=${DEFAULT_TIMER:-60}
 PLAY_LABEL=${PLAY_LABEL:-(playing)}
 PAUSE_LABEL=${PAUSE_LABEL:-(paused)}
 TIMER_LOOP=${TIMER_LOOP:-false}
+NEUTRAL_COLOR=${NEUTRAL_COLOR:-#000000}
 ###### Default environment variables ######
 
 ###### Functions ######
@@ -53,7 +54,7 @@ set_mode() {
       status_symbol=$PAUSE_LABEL
       time=${time-$DEFAULT_STOPWATCH}
       fgcolor='#FFFFFF'
-      bgcolor='#000000'
+      bgcolor=$NEUTRAL_COLOR
       incr=1
       ;;
   esac
@@ -135,15 +136,15 @@ $running && time=$(( time + incr ))
 if (( mode == 0 )); then
   if (( time <= 0 )); then
     bgcolor='#FF0000'
-    fgcolor='#000000'
+    fgcolor=$NEUTRAL_COLOR
     time=0
     pause
   elif (( time > 0 )); then
     fgcolor=$(compute_color $time)
-    bgcolor='#000000'
+    bgcolor=$NEUTRAL_COLOR
   fi
 else
-  bgcolor='#000000'
+  bgcolor=$NEUTRAL_COLOR
   fgcolor='#FFFFFF'
 fi
 full_text="${labels[$mode]} $status_symbol $(prettify_time)"


### PR DESCRIPTION
I am not using this blocklet much, but I've used it again and realized I hardcoded `#000000` (black) as the color for the neutral background.

For a while however, I've been using a non-black i3 bar, and having the background of a blocklet black is really ugly.

This commit exposes the variable `NEUTRAL_COLOR` to specify that color; it defaults to `#000000` otherwise.

As regards the other colors (for instance the colors from green to red for the timer), which can also be not ok for users who decide to give their i3 bars an "unconvetional" coloring, I think I could in the future export something like initial color, final color, and similar.