### PR TITLE
nm-vpn: fix vpn naming

### DIFF
--- a/nm-vpn/nm-vpn
+++ b/nm-vpn/nm-vpn
@@ -13,6 +13,7 @@ $3=="vpn" {
     color=init_color
 }
 $3=="tun" || ($4~/^tap/ || $3~/^tap/) {
+    if(!name) name=$1
     status="ON"
     color=on_color
 }


### PR DESCRIPTION
In case there is no VPN connection type, but TUN connection type established, naming is broken (e.g. ProtonVPN works so). So we can just use TUN name in that case VPN name absent.