### PR TITLE
Ignore cache when calculating free memory (setting)

### DIFF
--- a/memory2/README.md
+++ b/memory2/README.md
@@ -26,6 +26,7 @@ bar_chars=_▁▂▃▄▅▆▇█
 #warning=50
 #color_critical=#FF7373
 #color_warning=#FFA500
+#show_available=false
 ```
 
 E.g.
@@ -39,4 +40,5 @@ bar_size=20
 critical=50
 warning=20
 color_critical=#d9534f
+show_available=true
 ```

--- a/memory2/memory2.c
+++ b/memory2/memory2.c
@@ -156,8 +156,9 @@ int main(int argc, char *argv[])
   envvar = getenv("color_critical");
   if (envvar)
     color_critical = envvar;
+  envvar = getenv("show_available");
   if(envvar)
-    ignore_swap = (strcmp(getenv("show_available"), "false")) ? 1 : 0;
+    ignore_swap = (strcmp(envvar, "false")) ? 1 : 0;
   
   uint count = utf8_char_count(characters);
   utf8_char* bar_chars = (utf8_char*)malloc(count * sizeof(utf8_char));


### PR DESCRIPTION
Added a show_available environment variable.
The memory usage without this setting is almost always 100%.