### PR TITLE
rofi-calendar: add BAR_POSITION and WEEK_START variables

### DIFF
--- a/rofi-calendar/README.md
+++ b/rofi-calendar/README.md
@@ -22,6 +22,7 @@ Have a minimal calendar pop up in rofi when clicking the date blocklet (right cl
 command=$SCRIPT_DIR/rofi-calendar
 interval=3600
 #BAR_POSITION=bottom
+#WEEK_START=monday
 #DATEFTM=+%a %d %b %Y
 #SHORTFMT=+%d/%m/%Y
 #LABEL= 

--- a/rofi-calendar/README.md
+++ b/rofi-calendar/README.md
@@ -21,6 +21,7 @@ Have a minimal calendar pop up in rofi when clicking the date blocklet (right cl
 [rofi-calendar]
 command=$SCRIPT_DIR/rofi-calendar
 interval=3600
+#BAR_POSITION=bottom
 #DATEFTM=+%a %d %b %Y
 #SHORTFMT=+%d/%m/%Y
 #LABEL= 

--- a/rofi-calendar/rofi-calendar
+++ b/rofi-calendar/rofi-calendar
@@ -10,6 +10,7 @@ PREV_MONTH_TEXT="${PREV_MONTH_TEXT:-« previous month «}"
 NEXT_MONTH_TEXT="${NEXT_MONTH_TEXT:-» next month »}"
 ROFI_CONFIG_FILE="${ROFI_CONFIG_FILE:-/dev/null}"
 BAR_POSITION="${BAR_POSITION:-bottom}"
+WEEK_START="${WEEK_START:-monday}"
 ###### Variables ######
 
 
@@ -24,7 +25,7 @@ get_current_date() {
 print_month() {
   mnt=$1
   yr=$2
-  cal --color=always --monday $mnt $yr \
+  cal --color=always --$WEEK_START $mnt $yr \
     | sed -e 's/\x1b\[[7;]*m/\<b\>\<u\>/g' \
           -e 's/\x1b\[[27;]*m/\<\/u\>\<\/b\>/g' \
           -e '/^ *$/d' \

--- a/rofi-calendar/rofi-calendar
+++ b/rofi-calendar/rofi-calendar
@@ -9,6 +9,7 @@ LEFTCLICK_PREV_MONTH=${LEFTCLICK_PREV_MONTH:-false}
 PREV_MONTH_TEXT="${PREV_MONTH_TEXT:-« previous month «}"
 NEXT_MONTH_TEXT="${NEXT_MONTH_TEXT:-» next month »}"
 ROFI_CONFIG_FILE="${ROFI_CONFIG_FILE:-/dev/null}"
+BAR_POSITION="${BAR_POSITION:-bottom}"
 ###### Variables ######
 
 
@@ -106,6 +107,14 @@ case "$BLOCK_BUTTON" in
       else
         current_row=$(( $(echo $month_page | wc -l) - 1))
       fi
+
+      # check bar position and adjust anchor accordingly
+      if [[ $BAR_POSITION = "top" ]]; then
+        anchor="northeast"
+      else
+        anchor="southeast"
+      fi
+
       # open rofi and read the selected row
       # (add the following option to rofi command with proper config file, if needed)
       selected="$(echo $month_page \
@@ -116,7 +125,7 @@ case "$BLOCK_BUTTON" in
             -m -3 \
             -lines $(echo $month_page | wc -l) \
             -width -25 \
-            -theme-str '#window {anchor: southeast; location: northwest; }' \
+            -theme-str '#window {anchor: '"$anchor"'; location: northwest; }' \
             -theme $ROFI_CONFIG_FILE \
             -selected-row $(( current_row + bias_row )) \
             -p "$header")"


### PR DESCRIPTION
All changes are non-breaking, as default values for new variable are set. Details:

1. `BAR_POSITION` is added to make calendar visible for a bar on the top of the screen. This is done by specifying `anchor` variable for `rofi` command passed by the added variable. Possible further improvement is possibly passing a `$BAR_POSITION` variable from i3's `config` to `i3block.conf`.
2. `WEEK_START` simply takes advantage of the `--monday` and `--sunday` arguments of `cal` command.

`README.md` is updated to reflect the above.