### PR TITLE
backlight: remove decimal places from displayed screen brightness

### DIFF
--- a/backlight/backlight
+++ b/backlight/backlight
@@ -37,5 +37,5 @@ case $BLOCK_BUTTON in
 esac
 
 
-BRIGHTNESS=$(xbacklight -get)
+BRIGHTNESS=$(xbacklight -get | cut -f1 -d'.')
 echo "${BRIGHTNESS}%"


### PR DESCRIPTION
`xbacklight -get` (v1.2.3) shows several decimal places:

![image](https://user-images.githubusercontent.com/20794509/116464105-da28b500-a86b-11eb-9415-3cbfcb667a32.png)

Most users aren't interested in subdecimal screen brightness, but want a rounded value:

![image](https://user-images.githubusercontent.com/20794509/116463606-2fb09200-a86b-11eb-9e98-5a433201bcee.png)