### PR TITLE
backlight: L40 -- 'xbacklight -get' cut of the decimal places

### DIFF
--- a/backlight/backlight
+++ b/backlight/backlight
@@ -37,5 +37,5 @@ case $BLOCK_BUTTON in
 esac
 
 
-BRIGHTNESS=$(xbacklight -get)
+BRIGHTNESS=$(xbacklight -get | awk '{print int($1)}')
 echo "${BRIGHTNESS}%"


### PR DESCRIPTION
```suggestion
40: Cut off the decimal places of `xbacklight -get`.
```
While setting it up i3  I discovered that the `xbacklight` output shows a ton of decimal places. I decided to cut them off. That should be in line with the .png file you have in this repos (`example.png`). Thanks for all this Hope I am not wasting your time. Cheers, Steven