### PR TITLE
Remove note about i3blocks dynamic properties requirement

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -72,4 +72,6 @@ Want to contribute?
 Great!
 Check the link:https://github.com/vivien/i3blocks-contrib/blob/master/CONTRIBUTING.md[contribution guidelines] in order to get started.
 
+NOTE: i3blocks-contrib REQUIRES i3blocks v1.5 or higher, since it uses i3blocks dynamic properties.
+
 Happy crafting!

--- a/README.adoc
+++ b/README.adoc
@@ -72,8 +72,4 @@ Want to contribute?
 Great!
 Check the link:https://github.com/vivien/i3blocks-contrib/blob/master/CONTRIBUTING.md[contribution guidelines] in order to get started.
 
-NOTE: i3blocks now supports dynamics properties, and all scripts have been updated to do the same. +
-i3blocks-contrib REQUIRES a version of i3blocks that supports dynamics properties, which is currently only +
-available in the git version since the last release (v1.4) was years ago.
-
 Happy crafting!


### PR DESCRIPTION
v1.5 was released almost 2 years ago: https://github.com/vivien/i3blocks/releases/tag/1.5 with dynamic properties.