### PR TITLE
eyedropper: add support for Sway, and for copying to the clipboard

### DIFF
--- a/eyedropper/README.md
+++ b/eyedropper/README.md
@@ -25,6 +25,14 @@ For more information, visit [muquit/grabc](https://github.com/muquit/grabc)
 
 2. [fontawesome](https://github.com/FortAwesome/Font-Awesome)
 
+### Optional Dependencies
+
+1. xclip - for copying the value to clipboard in i3
+
+2. slurp, grim, imagemagick - for picking the color in SwayWM
+
+3. wl-clipboard - for copying the value to clipboard in SwayWM
+
 # Installation
 
 1. Copy script to your directory of choice
@@ -39,10 +47,17 @@ command=$SCRIPT_DIR/eyedropper
 full_text=<span foreground="#ffffff"></span>
 instance=#ffffff
 markup=pango
+#CLIPBOARD=true
+#SWAY=true
 ```
 
 - Change the "foreground" value in "full_text" to change the color of the initial eyedropper icon
 - Change the "instance" value to change the color of the hex value displayed
+
+Two environment variable configuration options are supported:
+
+1. CLIPBOARD=true - Copy the color value to the clipboard in addition to updating the string
+2. SWAY=true - Do color picking in a way that works when running in SwayWM (Wayland)
 
 ### Sample Look
 

--- a/eyedropper/eyedropper
+++ b/eyedropper/eyedropper
@@ -17,9 +17,21 @@
 
 color=$BLOCK_INSTANCE
 
-# sleep to cater to grabc startup time
-sleep 0.5
-value=$(grabc 2>/dev/null)
+if [ -z "${SWAY}" ]; then
+  # sleep to cater to grabc startup time
+  sleep 0.5
+  value=$(grabc 2>/dev/null)
+  if [ "${CLIPBOARD}" ]; then
+    i3-msg -q exec "xclip -sel clip < <(echo -n \\$value)"
+  fi
+else
+  value=$(grim -g "$(slurp -p -b '#00000000')" -t ppm - \
+    | convert - -format '%[pixel:s]' info:- \
+    | awk -F '[(,)]' '{printf("#%02x%02x%02x",$2,$3,$4)}')
+  if [ "${CLIPBOARD}" ]; then
+    swaymsg -q exec wl-copy "\\$value"
+  fi
+fi
 full_text="<span foreground=\"$value\"></span><span foreground=\"$color\">$value</span>"
 
 echo $full_text

--- a/eyedropper/i3block.conf
+++ b/eyedropper/i3block.conf
@@ -3,3 +3,5 @@ command=$SCRIPT_DIR/eyedropper
 full_text=<span foreground="#ffffff"></span>
 instance=#ffffff
 markup=pango
+#CLIPBOARD=true
+#SWAY=true


### PR DESCRIPTION
Please let me know if you think it would be better to create a separate blocklet for the Sway version instead of configuring this one as an option.