### PR TITLE
Use /tmp instead of /dev/shm to store path.

### DIFF
--- a/bandwidth/bandwidth
+++ b/bandwidth/bandwidth
@@ -19,7 +19,7 @@
 # Get custom IN and OUT labels if provided by command line arguments
 while [[ $# -gt 1 ]]; do
     key="$1"
-    case "$key" in 
+    case "$key" in
         -i|--inlabel)
             INLABEL="$2"
             shift;;
@@ -45,7 +45,7 @@ fi
 
 # Issue #36 compliant.
 if ! [ -e "/sys/class/net/${INTERFACE}/operstate" ] || \
-    (! [ "$TREAT_UNKNOWN_AS_UP" = "1" ] && 
+    (! [ "$TREAT_UNKNOWN_AS_UP" = "1" ] &&
     ! [ "`cat /sys/class/net/${INTERFACE}/operstate`" = "up" ])
 then
     echo "$INTERFACE down"
@@ -55,14 +55,14 @@ then
 fi
 
 # path to store the old results in
-path="/dev/shm/$(basename $0)-${INTERFACE}"
+path="/tmp/$(basename $0)-${INTERFACE}"
 
 # grabbing data for each adapter.
 read rx < "/sys/class/net/${INTERFACE}/statistics/rx_bytes"
 read tx < "/sys/class/net/${INTERFACE}/statistics/tx_bytes"
 
 # get time
-time=$(date +%s)
+time="$(date +%s)"
 
 # write current data if file does not exist. Do not exit, this will cause
 # problems if this file is sourced instead of executed as another process.


### PR DESCRIPTION
Why? It seems more reliable to use /tmp, as /dev/shm may not always be
present[1].

[1]: https://superuser.com/a/45509