### PR TITLE
shutdown_menu: update args for rofi 1.7.0

### DIFF
--- a/shutdown_menu/shutdown_menu
+++ b/shutdown_menu/shutdown_menu
@@ -38,7 +38,7 @@ BORDER_COLOR="${BORDER_COLOR:-#222222}"
 
 # Options not related to colors
 ROFI_TEXT="${ROFI_TEXT:-Menu:}"
-ROFI_OPTIONS=(${ROFI_OPTIONS:--width 11 -location 3 -hide-scrollbar -bw 2})
+ROFI_OPTIONS=(${ROFI_OPTIONS:--theme-str 'window {width: 11%; border: 2;} listview {scrollbar: false;}' -location 3})
 
 # Zenity options
 ZENITY_TITLE="${ZENITY_TITLE:-Menu}"


### PR DESCRIPTION
With the release of [rofi 1.7.0](https://github.com/davatorium/rofi/releases/tag/1.7.0), some arguments given to rofi by this script do not work anymore and it results in a badly styled window so I updated these to work with this new version.

I downgraded rofi to the previous version to see if there was any problem with previous versions and the script was working properly with my changes.