### PR TITLE
rofi-calendar: Update rofi call for rofi >=1.7

### DIFF
--- a/rofi-calendar/rofi-calendar
+++ b/rofi-calendar/rofi-calendar
@@ -124,9 +124,8 @@ case "$BLOCK_BUTTON" in
             -markup-rows \
             -font $FONT \
             -m -3 \
-            -lines $(echo $month_page | wc -l) \
-            -width -25 \
-            -theme-str '#window {anchor: '"$anchor"'; location: northwest; }' \
+            -theme-str 'window {width: 10%; anchor: '"$anchor"'; location: northwest;}' \
+            -theme-str 'listview {lines: '"$(echo $month_page | wc -l)"' ;scrollbar: false;}' \
             -theme $ROFI_CONFIG_FILE \
             -selected-row $(( current_row + bias_row )) \
             -p "$header")"


### PR DESCRIPTION
Similar to #418, rofi-calendar was broken on rofi 1.7.0.  
I also took the liberty to remove the scrollbar and adjust the default size for what looks good on my screen. Maybe screen width could be passed as an argument from i3blocks config ?

I tested the script for rofi 1.7 and made sure the changes were backwards compatible for rofi 1.6.1.