### PR TITLE
volume-pipewire fix forward sinks

### DIFF
--- a/volume-pipewire/volume-pipewire
+++ b/volume-pipewire/volume-pipewire
@@ -88,7 +88,7 @@ CAPABILITY=$(amixer -D $MIXER get $SCONTROL | sed -n "s/  Capabilities:.*cvolume
 
 function move_sinks_to_new_default {
     DEFAULT_SINK=$1
-    pactl list sink-inputs | grep index: | grep -o '[0-9]\+' | while read SINK
+    pactl list sink-inputs | grep 'Sink Input #' | grep -o '[0-9]\+' | while read SINK
     do
         pactl move-sink-input $SINK $DEFAULT_SINK
     done
@@ -96,9 +96,10 @@ function move_sinks_to_new_default {
 
 function set_default_playback_device_next {
     inc=${1:-1}
-    num_devices=$(pactl list sinks | grep -c index:)
-    sink_arr=($(pactl list sinks | grep index: | grep -o '[0-9]\+'))
-    default_sink_index=$(( $(pactl list sinks | grep index: | grep -no '*' | grep -o '^[0-9]\+') - 1 ))
+    num_devices=$(pactl list sinks | grep -c Name:)
+    sink_arr=($(pactl list sinks | grep Name: | sed -r 's/\s+Name: (.+)/\1/'))
+    default_sink=$(pactl get-default-sink)
+    default_sink_index=$(for i in "${!sink_arr[@]}"; do if [[ "$default_sink" = "${sink_arr[$i]}" ]]; then echo "$i"; fi done)
     default_sink_index=$(( ($default_sink_index + $num_devices + $inc) % $num_devices ))
     default_sink=${sink_arr[$default_sink_index]}
     pactl set-default-sink $default_sink


### PR DESCRIPTION
`volume-pipewire` does not seem to work when being clicked on. Its expected behavior is to forward to the next sink as default. However it's seemingly doing nothing. I debugged this issue on my Arch Linux Kernel 5.14.5-arch1-1, sway 1.6.1, pipewire 0.3.35, pactl 15.0, and found that `pactl list sink-inputs`'s outputs are wildly different than what was expected, which was probably imitating `volume-pulseaudio` . Here is a sample output from my install.

    Sink #47
      State: SUSPENDED
      Name: alsa_output.pci-0000_09_00.1.hdmi-stereo-extra4
      Description: Navi 21 HDMI Audio [Radeon RX 6800/6800 XT / 6900 XT] Digital Stereo (HDMI 5)
      Driver: PipeWire
      Sample Specification: s16le 2ch 48000Hz
      Channel Map: front-left,front-right
      Owner Module: 4294967295
      Mute: no
      Volume: front-left: 65520 / 100% / -0.01 dB,   front-right: 65520 / 100% / -0.01 dB
              balance 0.00
      Base Volume: 65536 / 100% / 0.00 dB
      Monitor Source: alsa_output.pci-0000_09_00.1.hdmi-stereo-extra4.monitor
      Latency: 0 usec, configured 0 usec
      Flags: HARDWARE DECIBEL_VOLUME LATENCY SET_FORMATS
      Properties:
        object.path = "alsa:pcm:0:hdmi:0,4:playback"
        api.alsa.path = "hdmi:0,4"
        api.alsa.pcm.card = "0"
        api.alsa.pcm.stream = "playback"
        audio.channels = "2"
        audio.position = "FL,FR"
        device.routes = "1"
        alsa.resolution_bits = "16"
        device.api = "alsa"
        device.class = "sound"
        alsa.class = "generic"
        alsa.subclass = "generic-mix"
        alsa.name = "HDMI 4"
        alsa.id = "HDMI 4"
        alsa.subdevice = "0"
        alsa.subdevice_name = "subdevice #0"
        alsa.device = "10"
        alsa.card = "0"
        alsa.card_name = "HDA ATI HDMI"
        alsa.long_card_name = "HDA ATI HDMI at 0xfca20000 irq 91"
        alsa.driver_name = "snd_hda_intel"
        device.profile.name = "hdmi-stereo-extra4"
        device.profile.description = "Digital Stereo (HDMI 5)"
        card.profile.device = "18"
        device.id = "42"
        factory.name = "api.alsa.pcm.sink"
        priority.driver = "584"
        priority.session = "584"
        media.class = "Audio/Sink"
        node.nick = "HDA ATI HDMI"
        node.name = "alsa_output.pci-0000_09_00.1.hdmi-stereo-extra4"
        device.description = "Navi 21 HDMI Audio [Radeon RX 6800/6800 XT / 6900 XT] Digital Stereo (HDMI 5)"
        device.icon_name = "audio-card-hdmi"
        device.bus = "pci"
        device.bus_path = "pci-0000:09:00.1"
        node.pause-on-idle = "false"
        factory.id = "18"
        client.id = "32"
        node.driver = "true"
        factory.mode = "merge"
        audio.adapt.follower = ""
        library.name = "audioconvert/libspa-audioconvert"
        object.id = "47"
        node.max-latency = "8192/48000"
      Ports:
        hdmi-output-4: HDMI / DisplayPort 5 (type: HDMI, priority: 5500, availability group: Legacy 5, available)
      Active Port: hdmi-output-4
      Formats:
        pcm

    Sink #49
      State: SUSPENDED
      Name: alsa_output.pci-0000_0b_00.4.analog-stereo
      Description: Starship/Matisse HD Audio Controller Analog Stereo
      Driver: PipeWire
      Sample Specification: s32le 2ch 48000Hz
      Channel Map: front-left,front-right
      Owner Module: 4294967295
      Mute: no
      Volume: front-left: 64665 /  99% / -0.35 dB,   front-right: 64665 /  99% / -0.35 dB
              balance 0.00
      Base Volume: 65536 / 100% / 0.00 dB
      Monitor Source: alsa_output.pci-0000_0b_00.4.analog-stereo.monitor
      Latency: 0 usec, configured 0 usec
      Flags: HARDWARE HW_MUTE_CTRL HW_VOLUME_CTRL DECIBEL_VOLUME LATENCY
      Properties:
        object.path = "alsa:pcm:1:front:1:playback"
        api.alsa.path = "front:1"
        api.alsa.pcm.card = "1"
        api.alsa.pcm.stream = "playback"
        audio.channels = "2"
        audio.position = "FL,FR"
        device.routes = "2"
        alsa.resolution_bits = "16"
        device.api = "alsa"
        device.class = "sound"
        alsa.class = "generic"
        alsa.subclass = "generic-mix"
        alsa.name = "ALC892 Analog"
        alsa.id = "ALC892 Analog"
        alsa.subdevice = "0"
        alsa.subdevice_name = "subdevice #0"
        alsa.device = "0"
        alsa.card = "1"
        alsa.card_name = "HD-Audio Generic"
        alsa.long_card_name = "HD-Audio Generic at 0xfc800000 irq 93"
        alsa.driver_name = "snd_hda_intel"
        device.profile.name = "analog-stereo"
        device.profile.description = "Analog Stereo"
        card.profile.device = "4"
        device.id = "44"
        factory.name = "api.alsa.pcm.sink"
        priority.driver = "945"
        priority.session = "945"
        media.class = "Audio/Sink"
        node.nick = "HD-Audio Generic"
        node.name = "alsa_output.pci-0000_0b_00.4.analog-stereo"
        device.description = "Starship/Matisse HD Audio Controller Analog Stereo"
        device.icon_name = "audio-card-analog"
        device.bus = "pci"
        device.bus_path = "pci-0000:0b:00.4"
        node.pause-on-idle = "false"
        factory.id = "18"
        client.id = "32"
        node.driver = "true"
        factory.mode = "merge"
        audio.adapt.follower = ""
        library.name = "audioconvert/libspa-audioconvert"
        object.id = "49"
        node.max-latency = "8192/48000"
      Ports:
        analog-output-lineout: Line Out (type: Line, priority: 9000, availability group: Legacy 4, available)
        analog-output-headphones: Headphones (type: Headphones, priority: 9900, availability group: Legacy 5, not available)
      Active Port: analog-output-lineout
      Formats:
        pcm

Notice that it does not indicate which sink is the current default. Also the format does not use `index:` to prefix sink number. To get default sink, you'd use `pactl get-default-sink`. Here is a sample output `alsa_output.pci-0000_09_00.1.hdmi-stereo-extra4`. Notice that it's not the sink number, but rather sink name. Fortunately `pactl set-default-sink` works with both sink number and sink name.

So this diff parses sinks by name instead of number. Forward it by `inc` and set it as default, again, by name. Finally `pactl list sink-inputs`'s output also mismatches expectation. Here is a sample

    Sink Input #63
      Driver: PipeWire
      Owner Module: n/a
      Client: 62
      Sink: 47
      Sample Specification: float32le 2ch 48000Hz
      Channel Map: front-left,front-right
      Format: pcm, format.sample_format = "\"float32le\""  format.rate = "48000"  format.channels = "2"  format.channel_map = "\"front-left,front-right\""
      Corked: no
      Mute: no
      Volume: front-left: 65536 / 100% / 0.00 dB,   front-right: 65536 / 100% / 0.00 dB
              balance 0.00
      Buffer Latency: 0 usec
      Sink Latency: 0 usec
      Resample method: PipeWire
      Properties:
        client.api = "pipewire-pulse"
        pulse.server.type = "unix"
        application.name = "Google Chrome"
        application.process.id = "10550"
        application.process.user = "initialxy"
        application.process.host = "initialxy-arch"
        application.process.binary = "chrome"
        application.language = "en_US.UTF-8"
        window.x11.display = ":0"
        application.process.machine_id = "9cb3b1ac2bf54a708524dc6cf8824e65"
        application.process.session_id = "1"
        application.icon_name = "google-chrome"
        media.name = "Playback"
        node.rate = "1/48000"
        stream.is-live = "true"
        node.name = "Google Chrome"
        node.autoconnect = "true"
        media.class = "Stream/Output/Audio"
        adapt.follower.node = ""
        object.register = "false"
        factory.id = "6"
        audio.adapt.follower = ""
        factory.mode = "split"
        library.name = "audioconvert/libspa-audioconvert"
        client.id = "62"
        object.id = "63"
        node.latency = "1024/48000"
        pulse.attr.maxlength = "4194304"
        pulse.attr.tlength = "24576"
        pulse.attr.prebuf = "20488"
        pulse.attr.minreq = "4096"
        module-stream-restore.id = "sink-input-by-application-name:Google Chrome"

Output number is prefixed by "Sink Input #" as opposed to "index:" so that's fixed as well.