### PR TITLE
dunst: simplifications and cleaning

### DIFF
--- a/dunst/README.md
+++ b/dunst/README.md
@@ -28,6 +28,5 @@ format=json
 markup=pango
 #min_width=50
 #align=center
-#DUNST_MUTE=off
 ```
 

--- a/dunst/dunst
+++ b/dunst/dunst
@@ -34,7 +34,7 @@ def mute_off():
 
 def clicked():
     '''Returns True if the button was clicked'''
-    button = "BLOCK_BUTTON" in os.environ and os.environ["BLOCK_BUTTON"]
+    button = os.environ.get("BLOCK_BUTTON", None)
     return bool(button)
 
 def muted():

--- a/dunst/dunst
+++ b/dunst/dunst
@@ -2,9 +2,7 @@
 """
 A do-not-disturb button for muting Dunst notifications in i3 using i3blocks
 
-Mute is handled by passing 'DUNST_COMMAND_PAUSE' and 'DUNST_COMMAND_RESUME' to
-the notify-send script and the 'DUNST_MUTE' environment variable is set to keep
-track of the toggle.
+Mute is handled using the `dunstctl` command.
 """
 
 __author__ = "Jessey White-Cinis <j@cin.is>"
@@ -16,21 +14,9 @@ import os
 import subprocess
 import json
 
-def mute_on():
-    '''Turns off dunst notifications'''
-    subprocess.run(["dunstctl", "set-paused", "true"], check=True)
-    return {
-        "full_text":"<span font='Font Awesome 5 Free Solid' color='#BE616E'>\uf1f6</span>",
-        "DUNST_MUTE":"on"
-    }
-
-def mute_off():
-    '''Turns back on dunst notifications'''
-    subprocess.run(["dunstctl", "set-paused", "false"], check=True)
-    return {
-        "full_text":"<span font='Font Awesome 5 Free Solid' color='#A4B98E'>\uf0f3</span>",
-        "DUNST_MUTE":"off"
-    }
+def mute_toggle():
+    '''Toggle dunst notifications'''
+    subprocess.run(["dunstctl", "set-paused", "toggle"], check=True)
 
 def clicked():
     '''Returns True if the button was clicked'''
@@ -46,16 +32,11 @@ def muted():
 
 if clicked():
     # toggle button click to turn mute on and off
-    if muted():
-        RTN = mute_off()
-    else:
-        RTN = mute_on()
+    mute_toggle()
 
+if muted():
+    RTN = {"full_text":"<span font='Font Awesome 5 Free Solid' color='#BE616E'>\uf1f6</span>"}
 else:
-    # Set default state using 'DUNST_MUTE' environment variable
-    if muted():
-        RTN = mute_on()
-    else:
-        RTN = mute_off()
+    RTN = {"full_text":"<span font='Font Awesome 5 Free Solid' color='#A4B98E'>\uf0f3</span>"}
 
 print(json.dumps(RTN))


### PR DESCRIPTION
- using more efficient dict.get single-lookup

<br>

- getting rid of unnecessary remnants of 'DUNST_MUTE' environment
  variable
- using `set-paused toggle` instead of manual checking and setting
  `on/off`
- json payload is not created inside the state-setting function