### PR TITLE
ytdl-mpv: Fix video playback by removing cache-default

### DIFF
--- a/ytdl-mpv/README.md
+++ b/ytdl-mpv/README.md
@@ -20,7 +20,6 @@ command=$SCRIPT_DIR/ytdl-mpv
 markup=pango
 interval=once
 signal=4
-#CACHE_DEFAULT=1048576
 #PLAYING_COLOR=red
 #NOT_PLAYING_COLOR=white
 ```

--- a/ytdl-mpv/ytdl-mpv
+++ b/ytdl-mpv/ytdl-mpv
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 #
-# Copyright (C) 2018 James Murphy
+# Copyright (C) 2018-2021 James Murphy, Falko Galperin
 # Licensed under the terms of the GNU GPL v2 only.
 #
 # i3blocks blocklet script to play youtube videos from your clipboard using mpv
@@ -10,7 +10,6 @@ use warnings;
 use utf8;
 use Data::Validate::URI;
 
-my $cache_default = $ENV{CACHE_DEFAULT} || 1048576;
 my $signal = $ENV{signal} || 1;
 my $notify_i3bar = "pkill -RTMIN+$signal i3blocks";
 my $string = qx/xclip -out/;
@@ -25,7 +24,7 @@ my $i3cmdexitstatus = 0;
 
 if ($uriValidator->is_web_uri($string) or $BLOCK_BUTTON == 3) {
     if ($BLOCK_BUTTON == 1) {
-        $i3cmd = "exec mpv --ytdl --cache-default=$cache_default --tls-verify '$string' && $notify_i3bar";
+        $i3cmd = "exec mpv --ytdl --tls-verify '$string' && $notify_i3bar";
     } elsif ($BLOCK_BUTTON == 2) {
         $i3cmd = "exec mpv --ytdl --tls-verify --ytdl-format=bestaudio '$string' && $notify_i3bar";
     } elsif ($BLOCK_BUTTON == 3) {


### PR DESCRIPTION
The parameter `--cache-default` has been removed from mpv, causing the
video playback to fail when run through this script. This pull request
removes the `--cache-default` parameter (and the corresponding
`CACHE_DEFAULT` environment variable), which causes the video
playback to work again.