### PR TITLE
volume-pipewire: fix display with non-english system locale

### DIFF
--- a/volume-pipewire/volume-pipewire
+++ b/volume-pipewire/volume-pipewire
@@ -3,6 +3,9 @@
 
 set -a
 
+# pactl output is localised (as opposed to pacmd)
+LC_ALL=C
+
 AUDIO_HIGH_SYMBOL=${AUDIO_HIGH_SYMBOL:-'  '}
 
 AUDIO_MED_THRESH=${AUDIO_MED_THRESH:-50}


### PR DESCRIPTION
pactl honours the system locale (as opposed to pacmd), so the parsing
(e.g. for the ACTIVE state) returns an empty string. This leads to
always showing "Sound inactive".