### PR TITLE
volume-pipewire: use default sink if inactive

### DIFF
--- a/volume-pipewire/volume-pipewire
+++ b/volume-pipewire/volume-pipewire
@@ -119,7 +119,11 @@ function print_format {
 }
 
 function print_block {
-    ACTIVE=$(pactl list sinks  | grep "State\: RUNNING" -B4 -A55 | grep "Name:\|Volume: \(front-left\|mono\)\|Mute:\|api.alsa.pcm.card = \|node.nick = ")
+    ACTIVE="$(pactl list sinks  | grep "State\: RUNNING" -B4 -A55)"
+    if [[ $ACTIVE = "" ]] ; then
+        ACTIVE="$(pactl list sinks | grep "$(pactl get-default-sink)" -B4 -A55)"
+    fi
+    ACTIVE="$(echo "$ACTIVE" | grep "Name:\|Volume: \(front-left\|mono\)\|Mute:\|api.alsa.pcm.card = \|node.nick = ")"
     for Name in NAME MUTED VOL INDEX NICK; do
         read $Name
     done < <(echo "$ACTIVE")


### PR DESCRIPTION
If all of the sinks are inactive, fall back to the default sink instead of saying "audio inactive". This allows changing the volume while no audio is playing.