### PR TITLE
 volume-pipewire: add active PORT

### DIFF
--- a/volume-pipewire/README.md
+++ b/volume-pipewire/README.md
@@ -57,7 +57,7 @@ interval=once
 signal=1
 #MIXER=[determined automatically]
 #SCONTROL=[determined automatically]
-##exposed format variables: ${SYMB}, ${VOL}, ${INDEX}, ${NAME}
+##exposed format variables: ${SYMB}, ${VOL}, ${INDEX}, ${NAME}, ${PORT}
 #LONG_FORMAT="${SYMB} ${VOL}% [${INDEX}:${NAME}]"
 #SHORT_FORMAT="${SYMB} ${VOL}% [${INDEX}]"
 #AUDIO_HIGH_SYMBOL='  '

--- a/volume-pipewire/volume-pipewire
+++ b/volume-pipewire/volume-pipewire
@@ -52,7 +52,7 @@ while getopts F:Sf:adH:M:L:X:T:t:C:c:i:m:s:h opt; do
         [-m mixer] [-s scontrol] [-h]
 Options:
 -F, -f\tOutput format (-F long format, -f short format) to use, with exposed variables:
-\${SYMB}, \${VOL}, \${INDEX}, \${NAME}
+\${SYMB}, \${VOL}, \${INDEX}, \${NAME}, \${PORT}
 -S\tSubscribe to volume events (requires persistent block, always uses long format)
 -a\tUse ALSA name if possible
 -d\tUse device description instead of name if possible
@@ -115,18 +115,19 @@ case "$BLOCK_BUTTON" in
 esac
 
 function print_format {
-    echo "$1" | envsubst '${SYMB}${VOL}${INDEX}${NAME}'
+    echo "$1" | envsubst '${SYMB}${VOL}${INDEX}${NAME}${PORT}'
 }
 
 function print_block {
-    ACTIVE=$(pactl list sinks  | grep "State\: RUNNING" -B4 -A55 | grep "Name:\|Volume: \(front-left\|mono\)\|Mute:\|api.alsa.pcm.card = \|node.nick = ")
-    for Name in NAME MUTED VOL INDEX NICK; do
+    ACTIVE=$(pactl list sinks  | grep "State\: RUNNING" -B4 -A66 | grep "Name:\|Volume: \(front-left\|mono\)\|Mute:\|api.alsa.pcm.card = \|node.nick = \|Active Port: " | sed 's/Active Port/Port/')
+    for Name in NAME MUTED VOL INDEX NICK PORT; do
         read $Name
     done < <(echo "$ACTIVE")
     INDEX=$(echo "$INDEX"  | grep -o '".*"' | sed 's/"//g')
     VOL=$(echo "$VOL" | grep -o "[0-9]*%" | head -1 )
     VOL="${VOL%?}"
     NAME=$(echo "$NICK" | grep -o '".*"' | sed 's/"//g')
+    PORT=$(echo "$PORT" | sed 's/.*] //g')
 
     if [[ $USE_ALSA_NAME == 1 ]] ; then
         ALSA_NAME=$(pactl list sinks |\


### PR DESCRIPTION
As in Title: waiting for [pactl: add format flag for JSON output (!497)](https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/merge_requests/497#note_0934b9201704b62cb1661b6eba196a814645e8ac) to be out, I just extended the existing volume-pipewire blocklet and add the Active Port variable `$PORT` to the format.