### PR TITLE
volume-pulseaudio: support active port

### DIFF
--- a/volume-pulseaudio/README.md
+++ b/volume-pulseaudio/README.md
@@ -45,7 +45,7 @@ interval=once
 signal=1
 #MIXER=[determined automatically]
 #SCONTROL=[determined automatically]
-##exposed format variables: ${SYMB}, ${VOL}, ${INDEX}, ${NAME}
+##exposed format variables: ${SYMB}, ${VOL}, ${INDEX}, ${NAME}, ${PORT}
 #LONG_FORMAT="${SYMB} ${VOL}% [${INDEX}:${NAME}]"
 #SHORT_FORMAT="${SYMB} ${VOL}% [${INDEX}]"
 #AUDIO_HIGH_SYMBOL='  '

--- a/volume-pulseaudio/volume-pulseaudio
+++ b/volume-pulseaudio/volume-pulseaudio
@@ -52,7 +52,7 @@ while getopts F:Sf:adH:M:L:X:T:t:C:c:i:m:s:h opt; do
         [-m mixer] [-s scontrol] [-j] [-h]
 Options:
 -F, -f\tOutput format (-F long format, -f short format) to use, with exposed variables:
-\${SYMB}, \${VOL}, \${INDEX}, \${NAME}
+\${SYMB}, \${VOL}, \${INDEX}, \${NAME}, \${PORT}
 -S\tSubscribe to volume events (requires persistent block, always uses long format)
 -a\tUse ALSA name if possible
 -d\tUse device description instead of name if possible
@@ -121,13 +121,14 @@ function print_format {
         output=$1
     fi
 
-    echo "$output" | envsubst '${SYMB}${VOL}${INDEX}${NAME}'
+    echo "$output" | envsubst '${SYMB}${VOL}${INDEX}${NAME}${PORT}'
 }
 
 function print_block {
-    ACTIVE=$(pacmd list-sinks | grep "state\: RUNNING" -B4 -A7 | grep "index:\|name:\|volume: \(front\|mono\)\|muted:")
-    [ -z "$ACTIVE" ] && ACTIVE=$(pacmd list-sinks | grep "index:\|name:\|volume: \(front\|mono\)\|muted:" | grep -A3 '*')
-    for name in INDEX NAME VOL MUTED; do
+    SINKS=$(pacmd list-sinks | grep "index:\|name:\|state:\|volume: \(front\|mono\)\|muted:\|active port:")
+    ACTIVE=$(echo "$SINKS" | grep "state\: RUNNING" -B2 -A3)
+    [ -z "$ACTIVE" ] && ACTIVE=$(echo "$SINKS" | grep -A5 '*')
+    for name in INDEX NAME STATE VOL MUTED PORT; do
         read $name
     done < <(echo "$ACTIVE")
     INDEX=$(echo "$INDEX" | grep -o '[0-9]\+')
@@ -136,6 +137,10 @@ function print_block {
 
     NAME=$(echo "$NAME" | sed \
 's/.*<.*\.\(.*\)>.*/\1/; t;'\
+'s/.*<\(.*\)>.*/\1/; t;'\
+'s/.*/unknown/')
+
+    PORT=$(echo "$PORT" | sed \
 's/.*<\(.*\)>.*/\1/; t;'\
 's/.*/unknown/')
 


### PR DESCRIPTION
Add support for active port, output through `${PORT}`.

Note that some minor refactoring is being done since `active port:` is output after `ports:` and `properties:`, the length of which varies across devices, so existing hard-coded pattern `grep "state\: RUNNING" -B4 -A7` no longer works.