### PR TITLE
Fixed memory2 ram calc

### DIFF
--- a/memory2/freeram.c
+++ b/memory2/freeram.c
@@ -1,0 +1,68 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+
+long getFreeRam()
+{
+    FILE *fpipe;
+    char *command = "grep MemAvailable /proc/meminfo";
+    char c = 0;
+
+    if (0 == (fpipe = (FILE*)popen(command, "r")))
+    {
+        perror("popen() failed.");
+        exit(EXIT_FAILURE);
+    }
+    
+    char textValue[30];
+
+    int count = 0;
+    while (fread(&c, sizeof c, 1, fpipe))
+    {
+        if(c >= '0' && c <= '9'){
+            textValue[count] = c;
+            count++;
+        }
+    }
+    textValue[count] = '\0';
+
+    pclose(fpipe);
+
+    long result = atol(textValue);
+
+    return result;
+
+}
+
+long getTotalRam()
+{
+    FILE *fpipe;
+    char *command = "grep MemTotal /proc/meminfo";
+    char c = 0;
+
+    if (0 == (fpipe = (FILE*)popen(command, "r")))
+    {
+        perror("popen() failed.");
+        exit(EXIT_FAILURE);
+    }
+    
+    char textValue[30];
+
+    int count = 0;
+    while (fread(&c, sizeof c, 1, fpipe))
+    {
+        if(c >= '0' && c <= '9'){
+            textValue[count] = c;
+            count++;
+        }
+    }
+    textValue[count] = '\0';
+
+    pclose(fpipe);
+
+    long result = atol(textValue);
+
+    return result;
+
+}

--- a/memory2/memory2.c
+++ b/memory2/memory2.c
@@ -6,6 +6,7 @@
 #include <unistd.h>
 #include <getopt.h>
 #include <sys/sysinfo.h>
+#include "freeram.c"
 
 #define RED "#FF7373"
 #define ORANGE "#FFA500"
@@ -120,11 +121,11 @@ int main(int argc, char *argv[])
     sysinfo_t info;
     sysinfo(&info);
 
-    long total = info.totalram;
-    long free  = info.freeram;
+    long total = getTotalRam();
+    long free  = getFreeRam();
     long usage = total - free;
     
-    float percent = 100 * ((float)usage / total);
+    float percent = 100 * ((float)usage / total );
     float bar_percent = percent;
 
     memset(buffer, 0, buffer_size);
@@ -152,7 +153,7 @@ int main(int argc, char *argv[])
       printf("<span>");
     }
 
-    const float byte_to_gb = 1024 * 1024 * 1024;
+    const float byte_to_gb = 1024 * 1024;
     
     float usage_gb = usage / byte_to_gb;
     float total_gb = total / byte_to_gb;


### PR DESCRIPTION
## Abstract

The value of ram was wrong in display, so I researched ways to make it right, and created two functions: `getFreeRam()` and `getTotalRam` wich will get the correct values about the avaliable and usage of memory ram 

## Functions

### getFreeRam()

Execute the command `grep MemAvailable /proc/meminfo` wich returns the amount of memory not used in the system and make some filtering to get only the number without the text

### getTotalRam()

Execute the command `grep MemTotal /proc/meminfo` wich returns the total memory size and make some filtering to get only the number without the text
