### PR TITLE
brightness: re-init file descriptors set. Fix high CPU consumption

### DIFF
--- a/brightness/main.c
+++ b/brightness/main.c
@@ -93,15 +93,15 @@ main(int argc, char *argv[]) {
     return -1;
   }
 
-  wd = inotify_add_watch(ifd, actual_brightness_path, IN_MODIFY);
-  FD_ZERO (&read_descriptors);
-  FD_SET (ifd, &read_descriptors);
-  time_to_wait.tv_sec = 10;
-  time_to_wait.tv_usec = 0;
+  wd = inotify_add_watch(ifd, actual_brightness_path ,
+                         IN_MODIFY | IN_CLOSE | IN_CREATE | IN_DELETE);
 
   while (1) {
-    fd_set tmp_set = read_descriptors;
-    rc = select(ifd+1, &tmp_set, NULL, NULL, &time_to_wait);
+    FD_ZERO (&read_descriptors);
+    FD_SET (ifd, &read_descriptors);
+    time_to_wait.tv_sec = 10;
+    time_to_wait.tv_usec = 0;
+    rc = select(ifd+1, &read_descriptors, NULL, NULL, &time_to_wait);
     if (rc < 0) {
       perror("select failed");
       break;


### PR DESCRIPTION
There is an issue on newest kernels with this droplet. CPU consumption - 100% . 
The reason is that select function returns result immediately. This happens because set of file descriptors is changed after first call. 
Fixed by re-initialization of descriptors set. 
Tested on Linux lezh1k-laptop 5.15.24-1-lts and on newest linux kernel.