### PR TITLE
iface: Add option to display the ip address

### DIFF
--- a/iface/i3blocks.conf
+++ b/iface/i3blocks.conf
@@ -7,3 +7,5 @@ color=#00FF00
 interval=10
 # set this to 1 to display the name of the connected WIFI interface instead of the IP address.
 display_wifi_name=0
+# set this to 0 to suppress the ip address
+display_ipaddr=1

--- a/iface/iface
+++ b/iface/iface
@@ -57,6 +57,10 @@ if [[ "$IF" = "" ]] || [[ "$(cat /sys/class/net/$IF/operstate)" = 'down' ]]; the
   exit
 fi
 
+# by default, print the ip address
+unset show_ipaddr
+[[ "$display_ipaddr" != 0 ]] && show_ipaddr=1
+
 # if no interface is found, use the first device with a global scope
 IPADDR=$(ip addr show $IF | perl -n -e "/$AF ([^ \/]+).* scope global/ && print \$1 and exit")
 
@@ -73,15 +77,15 @@ then
 
     if [[ $BLOCK_BUTTON -eq 1 ]];
     then
-      message="$LABEL $WIFI_NAME ($IPADDR)"
+      message="$LABEL $WIFI_NAME${show_ipaddr+ ($IPADDR)}"
     else
       message="$LABEL $WIFI_NAME"
     fi
   else
-    message="$LABEL $IPADDR"
+    message="$LABEL${show_ipaddr+ $IPADDR}"
   fi
 else
-  message="$LABEL $IPADDR"
+  message="$LABEL${show_ipaddr+ $IPADDR}"
 fi
 
 #------------------------------------------------------------------------


### PR DESCRIPTION
When set to 0, the `display_ipaddr` option suppresses the ip address.

The current behavior of displaying the ip address is preserved when
the option is unset or set to any other value, so no change is needed
for existing configs.