### PR TITLE
volume-pipewire: remove amixer dependency

### DIFF
--- a/volume-pipewire/volume-pipewire
+++ b/volume-pipewire/volume-pipewire
@@ -47,7 +47,7 @@ while getopts F:Sf:adH:M:L:X:T:t:C:c:i:m:s:h opt; do
         m) MIXER="$OPTARG" ;;
         s) SCONTROL="$OPTARG" ;;
         h) printf \
-"Usage: volume-pulseaudio [-S] [-F format] [-f format] [-p] [-a|-d] [-H symb] [-M symb]
+"Usage: volume-pipewire [-S] [-F format] [-f format] [-p] [-a|-d] [-H symb] [-M symb]
         [-L symb] [-X symb] [-T thresh] [-t thresh] [-C color] [-c color] [-i inter] 
         [-m mixer] [-s scontrol] [-h]
 Options:
@@ -72,20 +72,6 @@ Options:
     esac
 done
 
-if [[ -z "$MIXER" ]] ; then
-    MIXER="default"
-    if amixer -D pulse info >/dev/null 2>&1 ; then
-        MIXER="pulse"
-    fi
-fi
-
-if [[ -z "$SCONTROL" ]] ; then
-    SCONTROL=$(amixer -D "$MIXER" scontrols | sed -n "s/Simple mixer control '\([^']*\)',0/\1/p" | head -n1)
-fi
-
-CAPABILITY=$(amixer -D $MIXER get $SCONTROL | sed -n "s/  Capabilities:.*cvolume.*/Capture/p")
-
-
 function move_sinks_to_new_default {
     DEFAULT_SINK=$1
     pactl list sink-inputs | grep 'Sink Input #' | grep -o '[0-9]\+' | while read SINK
@@ -108,10 +94,10 @@ function set_default_playback_device_next {
 
 case "$BLOCK_BUTTON" in
     1) set_default_playback_device_next ;;
-    2) amixer -q -D $MIXER sset $SCONTROL $CAPABILITY toggle ;;
+    2) pactl set-sink-mute 0 toggle ;;
     3) set_default_playback_device_next -1 ;;
-    4) amixer -q -D $MIXER sset $SCONTROL $CAPABILITY $AUDIO_DELTA%+ ;;
-    5) amixer -q -D $MIXER sset $SCONTROL $CAPABILITY $AUDIO_DELTA%- ;;
+    4) pactl set-sink-volume 0 +$AUDIO_DELTA% ;;
+    5) pactl set-sink-volume 0 -$AUDIO_DELTA% ;;
 esac
 
 function print_format {


### PR DESCRIPTION
Pipewire doesn't depend on amixer and the script can work without it
Remove amixer usage and unused code, keep options for compatibility