### PR TITLE
purpleair: update deprecated URL and add API key support.

### DIFF
--- a/purpleair/README.md
+++ b/purpleair/README.md
@@ -17,11 +17,18 @@ A purpleair config block looks like this:
 label=
 command=$SCRIPT_DIR/purpleair
 interval=60
+API_KEY=01234567-89AB-CDEF-0123-456789ABCDEF
 SENSOR_ID=78305
 #TYPE=US_AQI
 #COLORS=#85df56,#fbcf4b,#f28c33,#dd4d3c,#cf79e0,#9b2f6a
 #NO_COLOR=true
 ```
+
+## Getting an API Key
+
+If you do not already have an API Key from PurpleAir, you can request one following the instructions in the *Introduction* section of [PupleAir's community guide article](https://community.purpleair.com/t/making-api-calls-with-the-purpleair-api/180).
+
+PurpleAir provides two keys: a *read* key and a *write* key. The *read* key must be used in the `API_KEY` parameter.
 
 ## Finding a sensor ID
 
@@ -40,6 +47,7 @@ There is one required parameter, along with some optional ones:
 
 Parameter | Description
 --------- | -----------
+API_KEY   | Required: Your PurpleAir *read* key
 SENSOR_ID | Required: The PurpleAir sensor to query
 TYPE      | Optional: The air quality computation to perform. Default: US_AQI
 COLORS    | Optional: Comma-separated list of color hex values to use in place of the default colors

--- a/purpleair/i3blocks.conf
+++ b/purpleair/i3blocks.conf
@@ -2,6 +2,7 @@
 label=
 command=$SCRIPT_DIR/purpleair
 interval=60
+API_KEY=01234567-89AB-CDEF-0123-456789ABCDEF
 SENSOR_ID=78305
 TYPE=US_AQI
 COLORS=#85df56,#fbcf4b,#f28c33,#dd4d3c,#cf79e0,#9b2f6a

--- a/purpleair/purpleair
+++ b/purpleair/purpleair
@@ -1,6 +1,13 @@
 #!/bin/perl
 # For temperature: subtract 8 from the F value for the actual temperature
 
+# Get PurpleAir API Key
+if ($ENV{'API_KEY'} == "") {
+  print STDERR "Missing required environment variable 'API_KEY'.\n";
+  exit 1;
+}
+$api_key = $ENV{'API_KEY'};
+
 # Get PurpleAir sensor ID
 if ($ENV{'SENSOR_ID'} == "") {
   print STDERR "Missing required environment variable 'SENSOR_ID'.\n";
@@ -19,8 +26,8 @@ if (grep(/^$ENV{'TYPE'}$/, @valid_types)) {
 }
 
 # Read pm2.5 10-minute average from the PurpleAir sensor
-$pm2_5 = `curl "http://purpleair.com/json?show=$sensor_id" 2>/dev/null \\
-    | jq -r '.results | map(select(has("Stats")) | .Stats | fromjson | .v1) | add / length'`;
+$pm2_5 = `curl -X GET "https://api.purpleair.com/v1/sensors/$sensor_id" -H "X-API-Key: $api_key" 2>/dev/null \\
+    | jq -r '.sensor.stats."pm2.5"'`;
 
 ###################
 # IMPLEMENTATIONS #


### PR DESCRIPTION
This PR fixes the purpleair blocklet. PurpleAir's old json API was turned down, so the blocklet no longer works as written at HEAD.

PurpleAir's new API requires an API Key and has a different output format. This PR updates the API URL, updates the response parsing, and updates the documentation with information on obtaining and using an API Key.