### PR TITLE
aur-update: add option to force IPV4 usage

### DIFF
--- a/aur-update/README.md
+++ b/aur-update/README.md
@@ -18,12 +18,14 @@ UPDATE_COLOR=red
 QUIET=1
 IGNORE=root vidyodesktop
 #CACHE_UPDATES=0
+#FORCE_IPV4=1
 ```
 
 Right or middle click sends a notification (via notify-send) with a list of outdated packages
 and the corresponding version information.
 If you enable caching (`CACHE_UPDATES=1`), the update list will be cached as an environment variable.
 This will be read on a (right/middle) click to directly show the notification without the delay caused by updating the list.
+Usage of IPV4 can be forced using `FORCE_IPV4=1`. This is useful, because the AUR API often gets timeouts with IPV6 and the call does not return.
 
 
 ## Dependencies

--- a/aur-update/aur-update
+++ b/aur-update/aur-update
@@ -20,6 +20,7 @@
 import json
 import os
 import requests
+import socket
 import subprocess as sp
 
 block_button = os.environ['BLOCK_BUTTON'] if 'BLOCK_BUTTON' in os.environ else None
@@ -43,6 +44,7 @@ args.add_argument('UPDATE_COLOR', 'yellow')
 args.add_argument('QUIET', False, bool)
 args.add_argument('IGNORE', [], list)
 args.add_argument('CACHE_UPDATES', False, bool)
+args.add_argument('FORCE_IPV4', 1, int)
 
 
 def version_in_aur(pkg):
@@ -75,6 +77,15 @@ def vcs_version(pkg, ver):
     # no base release to compare, just return None
     return None
 
+if args.force_ipv4:
+    # This is useful, because the AUR API often gets timeouts with
+    # IPV6 and the call does not return.
+
+    # monkey-patch this function to always return the IPV4-version,
+    # even if capable of IPV6
+    requests.packages.urllib3.util.connection.allowed_gai_family = (
+        lambda: socket.AF_INET
+    )
 
 # show the list of updates already cached
 if args.cache_updates and block_button in [2, 3]:

--- a/aur-update/aur-update
+++ b/aur-update/aur-update
@@ -57,7 +57,7 @@ def version_in_aur(pkg):
 
 
 def vcs_version(pkg, ver):
-    """ Try to find a sensble version for VSC packages
+    """ Try to find a sensible version for VSC packages
 
     If pkg looks like a VCS package according to
        https://wiki.archlinux.org/index.php/VCS_package_guidelines


### PR DESCRIPTION
Usage of IPV4 can be forced using `FORCE_IPV4=1`. This is useful, because the AUR API often gets timeouts with IPV6 and the call does not return.