### PR TITLE
aur-update: fixes

### DIFF
--- a/aur-update/aur-update
+++ b/aur-update/aur-update
@@ -41,9 +41,9 @@ class Args(object):
 
 args = Args()
 args.add_argument('UPDATE_COLOR', 'yellow')
-args.add_argument('QUIET', False, bool)
+args.add_argument('QUIET', 0, int)
 args.add_argument('IGNORE', [], list)
-args.add_argument('CACHE_UPDATES', False, bool)
+args.add_argument('CACHE_UPDATES', 0, int)
 args.add_argument('FORCE_IPV4', 1, int)
 
 


### PR DESCRIPTION
- if no updates and quiet, fill emtpy message (was crashing before)
- casting variables to int instead of bool (otherwise non-emtpy strings evaluate to True)