### PR TITLE
feat: more performant focused x window title script

### DIFF
--- a/x11_focused_window/LICENSE.md
+++ b/x11_focused_window/LICENSE.md
@@ -1,0 +1,16 @@
+The GPLv3 License (GPLv3)
+
+Copyright (c) 2022 Andis Spriņķis
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/x11_focused_window/README.md
+++ b/x11_focused_window/README.md
@@ -1,0 +1,7 @@
+# `x11_focused_window`
+
+Outputs title of the focused X11 window.
+
+Requirements - `xprop`, `bash`, GNU coreutils versions of `sed`, `sleep`.
+
+Author: Andis Spriņķis

--- a/x11_focused_window/i3blocks.conf
+++ b/x11_focused_window/i3blocks.conf
@@ -1,0 +1,5 @@
+[x11_focused_window]
+command=$SCRIPT_DIR/x11_focused_window
+interval=persist
+idle_seconds=0.125
+# GNU coreutils variant of 'sleep' supports floating point value.

--- a/x11_focused_window/x11_focused_window
+++ b/x11_focused_window/x11_focused_window
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+tick=0
+while :; do
+  prev_id="$id"
+  id=$(xprop -root | sed -n 's/_NET_ACTIVE_WINDOW(WINDOW): window id # \(.*.\)$/\1/p')
+
+  if [[ $tick -gt 10 ]] || [[ "$prev_id" != "$id" ]]; then 
+    prev_title="$title"
+    title=$(echo $(xprop -id $id | sed -n 's/_NET_WM_NAME(.*.= "\(.*.\)"$/\1/p'))
+    [[ "$prev_title" != "$title" ]] && echo ${title::90};
+    tick=0
+  fi
+  
+  tick=($tick+1)
+  sleep $idle_seconds > /dev/null 2>&1
+done


### PR DESCRIPTION
Almost instant focued X window title output with less CPU usage.

Meant as a performance improvement upon i3-focusedwindow, but due to GNU coreutils dependency and some opinionated output format differences, decided to put this in a separate util.