### PR TITLE
volume-pulseaudio: use [[ <cond> ]] instead of [ <cond> ]

### DIFF
--- a/volume-pulseaudio/volume-pulseaudio
+++ b/volume-pulseaudio/volume-pulseaudio
@@ -126,7 +126,7 @@ function print_format {
 
 function print_block {
     ACTIVE=$(pacmd list-sinks | grep "state\: RUNNING" -B4 -A7 | grep "index:\|name:\|volume: \(front\|mono\)\|muted:")
-    [ -z "$ACTIVE" ] && ACTIVE=$(pacmd list-sinks | grep "index:\|name:\|volume: \(front\|mono\)\|muted:" | grep -A3 '*')
+    [[ -z "$ACTIVE" ]] && ACTIVE=$(pacmd list-sinks | grep "index:\|name:\|volume: \(front\|mono\)\|muted:" | grep -A3 '*')
     for name in INDEX NAME VOL MUTED; do
         read $name
     done < <(echo "$ACTIVE")


### PR DESCRIPTION
A few lines below, `[[ <cond> ]]` is used indeed, so I think using `[ <cond> ]` was a typo.