### PR TITLE
brightness: Manage the label format on the label property.

### DIFF
--- a/brightness/README.md
+++ b/brightness/README.md
@@ -17,6 +17,8 @@ The result executable will be placed into bin directory.
 ```
 [brightness]
 command=./brightness/bin/brightness -a /sys/class/backlight/intel_backlight/actual_brightness -m /sys/class/backlight/intel_backlight/max_brightness
+# brightness symbol
+label=🔆
 interval=persist
 ```
 

--- a/brightness/main.c
+++ b/brightness/main.c
@@ -185,15 +185,13 @@ print_brightness_percent(const char *actual_path,
   for (size_t i = 0; i < 2; ++i) {
     bool success = get_float_value_from_file(parr[i], farr[i]);\
     if (!success) {
-      printf("\xF0\x9F\x94\x86"); //brightness symbol 🔆
-      printf(": NA\n");
+      printf("NA\n");
       fflush(stdout); // because we use select(), ant it blocks stdout
       return;
     }
   }
 
-  printf("\xF0\x9F\x94\x86"); //brightness symbol 🔆
-  printf(": %02.f%%\n", (curr / max) * 100.f);
+  printf("%02.f%%\n", (curr / max) * 100.f);
   fflush(stdout); // because we use select(), ant it blocks stdout
 }
 //////////////////////////////////////////////////////////////


### PR DESCRIPTION
This commit changes how to manage the label format, managing the label on the label property in the `config` file rather than managing the label format "[symbol]: " in `main.c`
It's helpful when aligning the label format with other blocklets.

You can check the modified README [here](https://github.com/junaruga/i3blocks-contrib/tree/wip/brightness-label/brightness).
