### PR TITLE
xkb_layout: fix cpu load in loop if xkb_switch fails

### DIFF
--- a/xkb_layout/xkb_layout
+++ b/xkb_layout/xkb_layout
@@ -10,7 +10,7 @@ font_weight=${font_weight:-bold}
 while :
 do
 # Output current layout:
-    xkb-switch -p | awk -v font="$font" -v font_weight="$font_weight" '{print "<span font_family=\""font"\"  font_weight=\""font_weight"\">"toupper($0)"</span>"}' || sleep 1
+    (xkb-switch -p || sleep 1) | awk -v font="$font" -v font_weight="$font_weight" '{print "<span font_family=\""font"\"  font_weight=\""font_weight"\">"toupper($0)"</span>"}'
 # Wait for layout change:
     xkb-switch -w
 done


### PR DESCRIPTION
Ran into a high cpu issue in the plugin when `xkb_switch` was not found:
```
~ > ps aux | sort -nrk 3,3 | head -n 5
estor    1074980 12.5  0.0 222932  3400 ?        S    15:38   0:02 sh /home/estor/.config/i3blocks/xkb_layout/xkb_layout
estor    1074953 12.5  0.0 222932  3328 ?        S    15:38   0:02 sh /home/estor/.config/i3blocks/xkb_layout/xkb_layout
estor    1074943 12.5  0.0 222932  3400 ?        S    15:38   0:02 sh /home/estor/.config/i3blocks/xkb_layout/xkb_layout
estor    1074930 12.5  0.0 222932  3400 ?        S    15:38   0:02 sh /home/estor/.config/i3blocks/xkb_layout/xkb_layout
estor    1074918 12.3  0.0 222932  3332 ?        S    15:38   0:02 sh /home/estor/.config/i3blocks/xkb_layout/xkb_layout
```

The problem is that the `awk` will return true even if the first program in the pipeline returned an error:
```
~ > false | awk -v font="$font" -v font_weight="$font_weight" '{print "<span font_family=\""font"\"  font_weight=\""font_weight"\">"toupper($0)"</span>"}' || echo "error"
~ > echo $?
0
```

As a solution, it was possible to change the command interpreter to `bash` and fix something like this:
`xkb-switch -p | awk -v font="$font" -v font_weight="$font_weight" '{print "<span font_family=\""font"\"  font_weight=\""font_weight"\">"toupper($0)"</span>"}'; [[ ${PIPESTATUS[0]} -ne 0  ]] && false || sleep 1`

But the `sh` works faster than `bash`, so I propose a solution from the commit.

In the future, you can fix the logic by recording the result of calling `xkb-switch -p` and increasing `sleep`, or even consider switching to `bash`. Now I propose to fix it this way.

P.S.
Already tried to fix it in the commit - https://github.com/vivien/i3blocks-contrib/commit/b51e17c6ab4928e7b151a862c8c90179ed24d2a6.