### PR TITLE
rofi-calendar: fix formatting bug

### DIFF
--- a/rofi-calendar/rofi-calendar
+++ b/rofi-calendar/rofi-calendar
@@ -27,7 +27,7 @@ print_month() {
   yr=$2
   cal --color=always --$WEEK_START $mnt $yr \
     | sed -e 's/\x1b\[[7;]*m/\<b\>\<u\>/g' \
-          -e 's/\x1b\[[27;]*m/\<\/u\>\<\/b\>/g' \
+          -e 's/\x1b\[[0;]*m/\<\/u\>\<\/b\>/g' \
           -e '/^ *$/d' \
     | tail -n +2
   echo $PREV_MONTH_TEXT$'\n'$NEXT_MONTH_TEXT


### PR DESCRIPTION
`cal` must have changed how it formats the current day some time ago, resulting in the bug shown in the attached screenshot. This commit fixes that, maybe also addressing #430, which seems to refer to the same bug, as long as I undersatand the description.

![brokenRofiCalendar](https://github.com/vivien/i3blocks-contrib/assets/20521900/85589fa9-da1a-4325-b4c9-5cce5f6cdcdd)
