### PR TITLE
arch-update: fix exit code 1 bug when using yay

### DIFF
--- a/arch-update/arch-update
+++ b/arch-update/arch-update
@@ -107,7 +107,14 @@ def get_aur_yaourt_updates():
     return aur_updates
 
 def get_aur_yay_updates():
-    output = check_output(['yay', '-Qua']).decode('utf-8')
+    output = ''
+    try:
+        output = check_output(['yaourt', '-Qua']).decode('utf-8')
+    except subprocess.CalledProcessError as exc:
+        # yay also exits with 1 and no output if no updates are available.
+        # we ignore this case and go on
+        if not (exc.returncode == 1 and not exc.output):
+            raise exc
     if not output:
         return []
 


### PR DESCRIPTION
yay also exits with exit code 1 when no aur packages need to be updated. the code should ignore this case and move on.