### PR TITLE
[mediaplayer] use playerctl's formatting support, keeping non-MPRIS

### DIFF
--- a/mediaplayer/mediaplayer
+++ b/mediaplayer/mediaplayer
@@ -122,19 +122,14 @@ sub mpd {
 sub playerctl {
     buttons('playerctl');
 
-    my $artist = qx(playerctl $player_arg metadata artist 2>/dev/null);
-    chomp $artist;
+    my $metadata = qx(playerctl $player_arg metadata \\
+        --format '{{default(artist, "\004\005")}} - {{title}}' 2>/dev/null);
+    chomp $metadata;
+    $metadata =~ s/^\004\005 - //;
     # exit status will be nonzero when playerctl cannot find your player
-    exit(0) if $? || $artist eq '(null)';
+    exit(0) if $? || $metadata eq '(null)';
 
-    push(@metadata, $artist) if $artist;
-
-    my $title = qx(playerctl $player_arg metadata title);
-    exit(0) if $? || $title eq '(null)';
-
-    push(@metadata, $title) if $title;
-
-    print(join(" - ", @metadata)) if @metadata;
+    print($metadata) if $metadata;
 }
 
 sub rhythmbox {


### PR DESCRIPTION
Ignores artist if absent (the hack of giving a control character default and stripping it is unfortunately necessary at the moment, cf https://github.com/altdesktop/playerctl/issues/296)

Closes: #498

(this approach doesn't touch the other code paths, and is offered if #499 is to be rejected)