### PR TITLE
[mediaplayer] Drop non-MPRIS players

### DIFF
--- a/mediaplayer/README.md
+++ b/mediaplayer/README.md
@@ -8,16 +8,10 @@ This displays "ARTIST - SONG" if music is playing. By
 left-clicking/right-clicking the displayed text, it will play the previous/next
 song. Middle-clicking will pause/unpause the song.
 
-Supported players are:
-- spotify, vlc, audacious, xmms2, mplayer and others that
-use MPRIS DBus Interface Specification
-- mpd
-- cmus
-- rhythmbox
+Any player supporting the MPRIS DBus Interface Specification is supported.
+Note you may need to install or enable a plugin for this.
 
-mpd is supported through mpc (music player client).
-
-For MPRIS support you need to have the playerctl binary in your path.
+You also need to have the playerctl binary in your path.
 See: https://github.com/acrisci/playerctl
 
 If you leave the instance empty playerctl will try to find an

--- a/mediaplayer/mediaplayer
+++ b/mediaplayer/mediaplayer
@@ -1,6 +1,7 @@
 #!/usr/bin/env perl
 # Copyright (C) 2014 Tony Crisci <tony@dubstepdish.com>
 # Copyright (C) 2015 Thiago Perrotta <perrotta dot thiago at poli dot ufrj dot br>
+# Copyright (C) 2023 Gesh <gesh@gesh.uni.cx>
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,8 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# For all media players except mpd/cmus/rhythmbox, MPRIS support should be
-# enabled and the playerctl binary should be in your path.
+# For all media players, MPRIS support should be enabled and the playerctl
+# binary should be in your path.
 # See https://github.com/acrisci/playerctl
 
 # Set instance=NAME in the i3blocks configuration to specify a music player
@@ -37,123 +38,31 @@ if ($BLOCK_INSTANCE) {
     $player_arg = "--player='$BLOCK_INSTANCE'";
 }
 
-sub buttons {
-    my $method = shift;
-
-    if($method eq 'mpd') {
-        if ($ENV{'BLOCK_BUTTON'} == 1) {
-            system("mpc prev &>/dev/null");
-        } elsif ($ENV{'BLOCK_BUTTON'} == 2) {
-            system("mpc toggle &>/dev/null");
-        } elsif ($ENV{'BLOCK_BUTTON'} == 3) {
-            system("mpc next &>/dev/null");
-        } elsif ($ENV{'BLOCK_BUTTON'} == 4) {
-            system("mpc volume +10 &>/dev/null");
-        } elsif ($ENV{'BLOCK_BUTTON'} == 5) {
-            system("mpc volume -10 &>/dev/null");
-        }
-    } elsif ($method eq 'cmus') {
-        if ($ENV{'BLOCK_BUTTON'} == 1) {
-            system("cmus-remote --prev");
-        } elsif ($ENV{'BLOCK_BUTTON'} == 2) {
-            system("cmus-remote --pause");
-        } elsif ($ENV{'BLOCK_BUTTON'} == 3) {
-            system("cmus-remote --next");
-        }
-    } elsif ($method eq 'playerctl') {
-        if ($ENV{'BLOCK_BUTTON'} == 1) {
-            system("playerctl $player_arg previous");
-            usleep(DELAY * 1000) if $BLOCK_INSTANCE eq SPOTIFY_STR;
-        } elsif ($ENV{'BLOCK_BUTTON'} == 2) {
-            system("playerctl $player_arg play-pause");
-        } elsif ($ENV{'BLOCK_BUTTON'} == 3) {
-            system("playerctl $player_arg next");
-            usleep(DELAY * 1000) if $BLOCK_INSTANCE eq SPOTIFY_STR;
-        } elsif ($ENV{'BLOCK_BUTTON'} == 4) {
-            system("playerctl $player_arg volume 0.01+");
-        } elsif ($ENV{'BLOCK_BUTTON'} == 5) {
-            system("playerctl $player_arg volume 0.01-");
-        }
-    } elsif ($method eq 'rhythmbox') {
-        if ($ENV{'BLOCK_BUTTON'} == 1) {
-            system("rhythmbox-client --previous");
-        } elsif ($ENV{'BLOCK_BUTTON'} == 2) {
-            system("rhythmbox-client --play-pause");
-        } elsif ($ENV{'BLOCK_BUTTON'} == 3) {
-            system("rhythmbox-client --next");
-        }
-    }
+if ($ENV{'BLOCK_BUTTON'} == 1) {
+    system("playerctl $player_arg previous");
+    usleep(DELAY * 1000) if $BLOCK_INSTANCE eq SPOTIFY_STR;
+} elsif ($ENV{'BLOCK_BUTTON'} == 2) {
+    system("playerctl $player_arg play-pause");
+} elsif ($ENV{'BLOCK_BUTTON'} == 3) {
+    system("playerctl $player_arg next");
+    usleep(DELAY * 1000) if $BLOCK_INSTANCE eq SPOTIFY_STR;
+} elsif ($ENV{'BLOCK_BUTTON'} == 4) {
+    system("playerctl $player_arg volume 0.01+");
+} elsif ($ENV{'BLOCK_BUTTON'} == 5) {
+    system("playerctl $player_arg volume 0.01-");
 }
 
-sub cmus {
-    my @cmus = split /^/, qx(cmus-remote -Q);
-    if ($? == 0) {
-        foreach my $line (@cmus) {
-            my @data = split /\s/, $line;
-            if (shift @data eq 'tag') {
-                my $key = shift @data;
-                my $value = join ' ', @data;
+my $artist = qx(playerctl $player_arg metadata artist 2>/dev/null);
+chomp $artist;
+# exit status will be nonzero when playerctl cannot find your player
+exit(0) if $? || $artist eq '(null)';
 
-                @metadata[0] = $value if $key eq 'artist';
-                @metadata[1] = $value if $key eq 'title';
-            }
-        }
+push(@metadata, $artist) if $artist;
 
-        if (@metadata) {
-            buttons('cmus');
+my $title = qx(playerctl $player_arg metadata title);
+exit(0) if $? || $title eq '(null)';
 
-            # metadata found so we are done
-            print(join ' - ', @metadata);
-            print("\n");
-            exit 0;
-        }
-    }
-}
+push(@metadata, $title) if $title;
 
-sub mpd {
-    my $data = qx(mpc current);
-    if (not $data eq '') {
-        buttons("mpd");
-        print($data);
-        exit 0;
-    }
-}
-
-sub playerctl {
-    buttons('playerctl');
-
-    my $artist = qx(playerctl $player_arg metadata artist 2>/dev/null);
-    chomp $artist;
-    # exit status will be nonzero when playerctl cannot find your player
-    exit(0) if $? || $artist eq '(null)';
-
-    push(@metadata, $artist) if $artist;
-
-    my $title = qx(playerctl $player_arg metadata title);
-    exit(0) if $? || $title eq '(null)';
-
-    push(@metadata, $title) if $title;
-
-    print(join(" - ", @metadata)) if @metadata;
-}
-
-sub rhythmbox {
-    buttons('rhythmbox');
-
-    my $data = qx(rhythmbox-client --print-playing --no-start);
-    print($data);
-}
-
-if ($player_arg =~ /mpd/) {
-    mpd;
-}
-elsif ($player_arg =~ /cmus/) {
-    cmus;
-}
-elsif ($player_arg =~ /rhythmbox/) {
-    rhythmbox;
-}
-else {
-    playerctl;
-}
+print(join(" - ", @metadata)) if @metadata;
 print("\n");


### PR DESCRIPTION
As clarified in #499, this is less of a problem than it appears, since the players dropped support MPRISv2 - some natively, some with a builtin plugin that needs to be enabled, and some with a well-supported plugin

Closes: #499