### PR TITLE
Fix README.md to include command in example configuration

### DIFF
--- a/metars/README.md
+++ b/metars/README.md
@@ -10,6 +10,7 @@ Configuration sample:
 
 ```
 [metars]
+command=$SCRIPT_DIR/metars
 interval=2100
 METARSSTATION=EFHK
 METARSURL=https://tgftp.nws.noaa.gov/data/observations/metar/stations/{}.TXT


### PR DESCRIPTION
I was playing around with this METAR script and couldn't get it to work until I added the command. I just wanted to fix this so others didn't have to figure out themselves.