### PR TITLE
cpu_usage2: fix build failures on clang/llvm

### DIFF
--- a/cpu_usage2/cpu_usage2.c
+++ b/cpu_usage2/cpu_usage2.c
@@ -124,7 +124,7 @@ int main(int argc, char *argv[])
     sleep(t);
     total = get_usage(&used);
 
-    display(label, 100.0D * (used - old_used) / (total - old_total),
+    display(label, 100.0 * (used - old_used) / (total - old_total),
             warning, critical, decimals);
     fflush(stdout);
     old_total = total;


### PR DESCRIPTION
Remove a non-standard suffix on a floating-point literal, causing build failures on clang/LLVM

fixes #504