### PR TITLE
Do not die "silently" in battery

### DIFF
--- a/battery/battery
+++ b/battery/battery
@@ -36,7 +36,7 @@ if (not defined($acpi)) {
     exit(0);
 }
 elsif ($acpi !~ /: ([\w\s]+), (\d+)%/) {
-	die "$acpi\n";
+	die "Unexpected acpi output: $acpi\n";
 }
 
 $status = $1;


### PR DESCRIPTION
Make a bit cleaner that battery script finished with error (wrong exit signal, thus it will not be displayed in i3blocks).