### PR TITLE
brightness: Stop busy waiting on Linux

### DIFF
--- a/brightness/main.c
+++ b/brightness/main.c
@@ -96,10 +96,14 @@ main(int argc, char *argv[]) {
   wd = inotify_add_watch(ifd, actual_brightness_path, IN_MODIFY);
   FD_ZERO (&read_descriptors);
   FD_SET (ifd, &read_descriptors);
-  time_to_wait.tv_sec = 10;
-  time_to_wait.tv_usec = 0;
 
   while (1) {
+    // We need to configure time_to_wait before each call of select,
+    // as according to the `select(2)` man page:
+    // "On Linux, select() modifies timeout to reflect the amount of time not slept"
+    time_to_wait.tv_sec = 10;
+    time_to_wait.tv_usec = 0;
+
     fd_set tmp_set = read_descriptors;
     rc = select(ifd+1, &tmp_set, NULL, NULL, &time_to_wait);
     if (rc < 0) {


### PR DESCRIPTION
This was happening on Linux after the first call to `select` in the while loop.
The `time_to_wait` was reset to have `tv_sec == 0` by the `select()` call and this
would effectively make us busy wait which would cause high CPU usage.

This is how `select()` works on Linux as per the [man page](https://man7.org/linux/man-pages/man2/select.2.html#:~:text=On%20Linux%2C%20select()%20modifies%20timeout%20to%20reflect%20the%20amount%20of%20time)