### PR TITLE
Fix mediaplayer display issue with new line chars

### DIFF
--- a/mediaplayer/mediaplayer
+++ b/mediaplayer/mediaplayer
@@ -101,8 +101,9 @@ sub cmus {
 
         if (@metadata) {
             buttons('cmus');
-
             # metadata found so we are done
+            # remove potential new line char
+            chomp(@metadata);
             print(join ' - ', @metadata);
             print("\n");
             exit 0;
@@ -133,7 +134,8 @@ sub playerctl {
     exit(0) if $? || $title eq '(null)';
 
     push(@metadata, $title) if $title;
-
+    # remove potential new line char
+    chomp(@metadata);
     print(join(" - ", @metadata)) if @metadata;
 }
 


### PR DESCRIPTION
Fixes issue where new line chars mean the output will be messed up and won't fit within the bar. Also experienced by https://github.com/vivien/i3blocks-contrib/issues/182

Current behaviour:
only "Artist Name" shown

After:
"Artist Name - Song Name" shown

Chomp removes trailing new line chars.
https://perldoc.perl.org/functions/chomp

I noticed this with spotify - turns out the artist name is returned with a new line char at the end. Simple command to verify this:

```
playerctl --player=spotify metadata artist | grep -q $'\n' && echo "Newline found" || echo "No newline"
```
This PR is mainly so others can find the fix