### PR TITLE
fixed print of bell-emoji in dunst blocklet

### DIFF
--- a/dunst/dunst
+++ b/dunst/dunst
@@ -13,6 +13,7 @@ __version__ = "1.1.0"
 import os
 import subprocess as sp
 import json
+import sys
 
 def mute_toggle():
     '''Toggle dunst notifications'''
@@ -37,4 +38,4 @@ if muted():
 else:
     RTN = {"full_text":"<span font='Font Awesome 5 Free Solid' color='#A4B98E'>\uf0f3</span>"}
 
-print(json.dumps(RTN))
+print(json.dumps(RTN, ensure_ascii=False))


### PR DESCRIPTION
Got problem, when instead of emoji was printed a emoji-code.