### PR TITLE
bandwidth2: use binary and decimal prefixes as appropriate

### DIFF
--- a/bandwidth2/bandwidth2.c
+++ b/bandwidth2/bandwidth2.c
@@ -131,8 +131,8 @@ int main(int argc, char *argv[])
   char *envvar = NULL;
   char *label = "";
 
-  char *prefixes_SI[] = { "", "K", "M", "G", 0 };
-  char *prefixes_BI[]  = { "", "Ki", "Mi", "Gi", 0 };
+  char *prefixes_SI[] = { " ",  "K",  "M",  "G",  0 };
+  char *prefixes_BI[] = { "  ", "Ki", "Mi", "Gi", 0 };
   char **prefixes = prefixes_BI;
 
   envvar = getenv("USE_BITS");


### PR DESCRIPTION
the implementation is through null-terminated arrays of decimal SI and binary SI prefixes. the appropriate array is passed to display(), which loops over it.