### PR TITLE
bandwidth2: fix interfaces logic

### DIFF
--- a/bandwidth2/bandwidth2.c
+++ b/bandwidth2/bandwidth2.c
@@ -51,11 +51,11 @@ void get_values(char **const ifaces, int num_ifaces, time_t * const s, ulli * co
   *received = 0;
   *sent = 0;
   while (fgets(line, BUFSIZ - 1, f) != NULL) {
-    if (sscanf(line, "%[^:]: %llu %*u %*u %*u %*u %*u %*u %*u %llu", ifname, &temp_r, &temp_s) == 3) {
+    if (sscanf(line, " %[^:]: %llu %*u %*u %*u %*u %*u %*u %*u %llu", ifname, &temp_r, &temp_s) == 3) {
       int i;
       int iface_found = num_ifaces == 0;
       for (i = 0; i < num_ifaces; i++) {
-        if (strcmp(ifaces[i], ifname) != 0) {
+        if (strcmp(ifaces[i], ifname) == 0) {
           iface_found = 1;
           break;
         }


### PR DESCRIPTION
the -i flag was not working as documented. the underlying reasons were 1) not accounting for whitespace padding in /proc/net/dev 2) incorrect usage of strcmp, which returns 0 for equal strings