### PR TITLE
aur-update: Fix VCS vercmp, add glob ignoring

### DIFF
--- a/aur-update/README.md
+++ b/aur-update/README.md
@@ -4,6 +4,13 @@ List available updates from the Arch User Repository (AUR)
 
 ![](example.png)
 
+Note: Logic depends on checking installed version against aurweb, so it doesn't
+work well for VCS packages.
+Instead, these need to run `makepkg --nodep -nobuild` on the actual `PKGBUILD`,
+then either construct the version string via `makepkg --printsrcinfo` or parse
+`makepkg --packagelist`, probably setting `PKG{DEST,EXT}` to controlled values
+to make parsing more predictable.
+
 ## Setup / Usage
 
 Example i3blocks configuration:
@@ -32,4 +39,4 @@ Usage of IPV4 can be forced using `FORCE_IPV4=1`. This is useful, because the AU
 
 - python3 [requests library](http://docs.python-requests.org/en/master/)
 - optional: libnotify/notify-send
-
+- pyalpm

--- a/aur-update/aur-update
+++ b/aur-update/aur-update
@@ -18,6 +18,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import pyalpm
+import re
+import fnmatch
 import json
 import os
 import requests
@@ -88,7 +90,7 @@ for pkg in packages.split('\n'):
 
 updates = []
 for pkg in installed_version.keys():
-    if pkg in args.ignore:
+    if any(re.match(fnmatch.translate(p), pkg) for p in args.ignore):
         continue
     v_aur = version_in_aur(pkg)
     v_inst = installed_version[pkg]

--- a/aur-update/aur-update
+++ b/aur-update/aur-update
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import pyalpm
 import json
 import os
 import requests
@@ -57,26 +58,6 @@ def version_in_aur(pkg):
 
     return "NotFound"
 
-
-def vcs_version(pkg, ver):
-    """ Try to find a sensible version for VSC packages
-
-    If pkg looks like a VCS package according to
-       https://wiki.archlinux.org/index.php/VCS_package_guidelines
-    try to extract a sensible (= comparable) version number.
-    """
-
-    suffices = ['-cvs', '-svn', '-hg', '-darcs', '-bzr', '-git']
-    if not any(pkg.endswith(suffix) for suffix in suffices):
-        # does not look like a VCS package
-        return ver
-
-    if '.r' in ver:
-        # of the form RELEASE.rREVISION: only use the release
-        return ver.split('.r')[0]
-    # no base release to compare, just return None
-    return None
-
 if args.force_ipv4:
     # This is useful, because the AUR API often gets timeouts with
     # IPV6 and the call does not return.
@@ -111,7 +92,7 @@ for pkg in installed_version.keys():
         continue
     v_aur = version_in_aur(pkg)
     v_inst = installed_version[pkg]
-    if vcs_version(pkg, v_aur) != vcs_version(pkg, v_inst):
+    if pyalpm.vercmp(v_inst, v_aur) < 0:
         updates.append(pkg + ' (%s -> %s)' % (v_inst, v_aur))
 
 # create the message for the block


### PR DESCRIPTION
-   **Use pyalpm.vercmp instead of rolling our own for VCS packages**

    Semantically more correct, though TBH for VCS packages there is no good
    substitute to querying `pkgver()` by running `makepkg`.
-   **aur-update: Allow IGNORE to match globs**

    Especially useful for eg ignoring *-debug packages
