### PR TITLE
temperature-nbfc: Add NBFC temperature reading

### DIFF
--- a/temperature-nbfc/README.md
+++ b/temperature-nbfc/README.md
@@ -1,0 +1,15 @@
+# temperature-nbfc
+
+Show NBFC-reported system temperature.
+
+# Dependencies
+
+- `nbfc`
+- `awk`
+
+# Usage
+
+``` ini
+[temperature-nbfc]
+command=$SCRIPT_DIR/temperature-nbfc
+```

--- a/temperature-nbfc/temperature-nbfc
+++ b/temperature-nbfc/temperature-nbfc
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+nbfc status | awk -F: \
+    '$1 ~ /Temperature */ { gsub(/ /,"",$2); printf "%s°C\n%s°C\n", $2, $2 }'


### PR DESCRIPTION
Mostly useful both for sanity-checking the lm-sensors reading and diagnosing
NBFC behaviour
