### PR TITLE
Update i3blocks.conf for user block

### DIFF
--- a/user/i3blocks.conf
+++ b/user/i3blocks.conf
@@ -1,5 +1,5 @@
 [user]
 #label= # Install fontawesome for use this
 label=User: 
-command=lslogins | grep $USER | awk '{print $5,$NF}'
+command=lslogins | grep $USER | awk '{print substr($0,index($0,$5))}'
 interval=once


### PR DESCRIPTION
The current implementation does not work if the full name is composed by more than two words.