### PR TITLE
wifi: `/usr/sbin` is not mandatory for normal user in Debian

### DIFF
--- a/wifi/wifi
+++ b/wifi/wifi
@@ -14,6 +14,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+PATH="$PATH:/usr/sbin"
+
 #------------------------------------------------------------------------
 if [[ -z "$INTERFACE" ]] ; then
     INTERFACE="${BLOCK_INSTANCE:-wlan0}"


### PR DESCRIPTION
Since `iw` lands in `/usr/sbin` in Debian, we just have to make sure that the binary is reachable, at last.