### PR TITLE
feature(batterybar): add Not charging status

### DIFF
--- a/batterybar/batterybar
+++ b/batterybar/batterybar
@@ -25,7 +25,7 @@ battery_count=${#output[@]}
 for line in "${output[@]}";
 do
     percentages+=($(echo "$line" | grep -o -m1 '[0-9]\{1,3\}%' | tr -d '%'))
-    statuses+=($(echo "$line" | egrep -o -m1 'Discharging|Charging|AC|Full|Unknown'))
+    statuses+=("$(echo "$line" | egrep -o -m1 'Discharging|Not charging|Charging|AC|Full|Unknown')")
     remaining=$(echo "$line" | egrep -o -m1 '[0-9][0-9]:[0-9][0-9]')
     if [[ -n $remaining ]]; then
         remainings+=(" ($remaining)")
@@ -99,7 +99,7 @@ do
     "Full")
         color="$full_color"
     ;;
-    "AC")
+    "AC"|"Not charging")
         color="$ac_color"
     ;;
     "Discharging"|"Unknown")


### PR DESCRIPTION
My Lenovo T14 laptop enters a "Not charging" state when it's connected to AC but has more than 90% battery left.

Since it's on AC, I handled the case by aliasing it to the "AC" status.