### PR TITLE
arch-update: add paru support for aur packages

### DIFF
--- a/arch-update/README.md
+++ b/arch-update/README.md
@@ -40,7 +40,10 @@ QUIET=true
 WATCH=^linux.* ^pacman.*
 BASE_COLOR=#5fff5f
 UPDATE_COLOR=#FFFF85
+# Should only have one AUR method at a time
 AUR=true
+#AUR_YAY=true
+#AUR_PARU=true
 LABEL= 
 ```
 # Configuration
@@ -51,4 +54,6 @@ _Use the environment variables above instead of these deprecated command line op
 - `-b`/`--base_color`: set the base color of the output (when your system is up to date)
 - `-u`/`--updates_available_color`: set the color of the output when updates are available
 - `-a`/`--aur`: activate AUR update support  
+- `-y`/`--aur_yay`: activate AUR update support using yay
+- `-p`/`--aur_paru`: activate AUR update support using paru
 For the latest options call `$SCRIPT_DIR/arch-update -h`.

--- a/arch-update/arch-update
+++ b/arch-update/arch-update
@@ -51,6 +51,14 @@ def create_argparse():
         help='Include AUR packages. Attn: Yay must be installed'
     )
     parser.add_argument(
+        '-p',
+        '--aur_paru',
+        action = 'store_const',
+        const = True,
+        default = _default('AUR_PARU', 'False', strbool),
+        help='Include AUR packages. Attn: Paru must be installed'
+    )
+    parser.add_argument(
         '-q',
         '--quiet',
         action = 'store_const',
@@ -115,6 +123,14 @@ def get_aur_yay_updates():
 
     return aur_updates
 
+def get_aur_paru_updates():
+    output = check_output(['paru', '-Qua']).decode('utf-8')
+    if not output:
+        return []
+
+    aur_updates = [line.split(' ')[0] for line in output.split('\n') if line]
+
+    return aur_updates
 
 def matching_updates(updates, watch_list):
     matches = set()
@@ -135,6 +151,8 @@ if args.aur:
     updates += get_aur_yaourt_updates()
 elif args.aur_yay:
     updates += get_aur_yay_updates()
+elif args.aur_paru:
+    updates += get_aur_paru_updates()
 
 update_count = len(updates)
 if update_count > 0:


### PR DESCRIPTION
Added paru support in the `arch-update` blocklet to check aur updates in archlinux and added some help in the README.md to show how to use it and the yay functionnality in the cli and the `i3blocks.conf`.