### PR TITLE
Arch update yay no update fix

### DIFF
--- a/arch-update/README.md
+++ b/arch-update/README.md
@@ -11,6 +11,7 @@ Be always on top of your available updates with this blocklet. Optionally show A
 * Arch Linux or another arch based distro
 * python3
 * [pacman-contrib](https://www.archlinux.org/packages/?name=pacman-contrib) for `checkupdates`
+* `yay` installed and available in PATH (if you intend on having yay + pacman updates)
 
 # Optional Dependencies
 
@@ -41,6 +42,14 @@ WATCH=^linux.* ^pacman.*
 BASE_COLOR=#5fff5f
 UPDATE_COLOR=#FFFF85
 AUR=true
+LABEL= 
+```
+Another example with AUR updates enabled:
+```ini
+[arch-updates]
+command=$SCRIPT_DIR/arch-update/arch-update -y
+markup=pango
+interval=3600
 LABEL= 
 ```
 # Configuration

--- a/arch-update/arch-update
+++ b/arch-update/arch-update
@@ -112,7 +112,7 @@ def get_aur_yay_updates():
         output = check_output(['yay', '-Qua']).decode('utf-8')
     except subprocess.CalledProcessError as exc:
         # yay returns exit code 1 when no AUR updates are availbale - safe to ignore
-        if not (exc.returncode == 2 and not exc.output):
+        if not (exc.returncode == 1 and not exc.output):
             raise exc
     if not output:
         return []

--- a/arch-update/arch-update
+++ b/arch-update/arch-update
@@ -107,14 +107,16 @@ def get_aur_yaourt_updates():
     return aur_updates
 
 def get_aur_yay_updates():
-    output = check_output(['yay', '-Qua']).decode('utf-8')
-    if not output:
+    try:
+        output = check_output(['yay', '-Qua']).decode('utf-8')
+        if not output:
+            return []
+
+        aur_updates = [line.split(' ')[0] for line in output.split('\n') if line]
+
+        return aur_updates
+    except:
         return []
-
-    aur_updates = [line.split(' ')[0] for line in output.split('\n') if line]
-
-    return aur_updates
-
 
 def matching_updates(updates, watch_list):
     matches = set()

--- a/arch-update/arch-update
+++ b/arch-update/arch-update
@@ -107,16 +107,21 @@ def get_aur_yaourt_updates():
     return aur_updates
 
 def get_aur_yay_updates():
+    output = ''
     try:
         output = check_output(['yay', '-Qua']).decode('utf-8')
-        if not output:
-            return []
-
-        aur_updates = [line.split(' ')[0] for line in output.split('\n') if line]
-
-        return aur_updates
-    except:
+    except subprocess.CalledProcessError as exc:
+        # yay returns exit code 1 when no AUR updates are availbale - safe to ignore
+        if not (exc.returncode == 2 and not exc.output):
+            raise exc
+    if not output:
         return []
+
+    aur_updates = [line.split(' ')[0] 
+                    for line in output.split('\n') 
+                    if line]
+
+    return aur_updates
 
 def matching_updates(updates, watch_list):
     matches = set()


### PR DESCRIPTION
**Reason for PR:**
![image](https://github.com/user-attachments/assets/ab30aba6-8d64-4fb3-a44a-f69c4edcd503)

**Included in This PR:**

- arch-updates/arch-update — Python script for the block - it was update to handle when there are no updates for yay
- arch-updates/README.md — An new example with the flag -y added to the i3blocks.config & adding yay as a dependency if the option of AUR is either true or the flag -y is enabled