### PR TITLE
rofi-calendar: improve ANSI escape sequence handling in print_month()

### DIFF
--- a/rofi-calendar/rofi-calendar
+++ b/rofi-calendar/rofi-calendar
@@ -26,8 +26,8 @@ print_month() {
   mnt=$1
   yr=$2
   cal --color=always --$WEEK_START $mnt $yr \
-    | sed -e 's/\x1b\[[7;]*m/\<b\>\<u\>/g' \
-          -e 's/\x1b\[[27;]*m/\<\/u\>\<\/b\>/g' \
+    | sed -e 's/\x1b\[[0-9;]*7[0-9;;]*m/<b><u>/g' \
+          -e 's/\x1b\[\(0\|27\)[0-9;]*m/<\/u><\/b>/g' \
           -e '/^ *$/d' \
     | tail -n +2
   echo $PREV_MONTH_TEXT$'\n'$NEXT_MONTH_TEXT


### PR DESCRIPTION
Fixes: #430

This pull request includes a change to the `print_month()` function in the `rofi-calendar` script to improve the handling of ANSI escape sequences for formatting calendar output. The most important change involves updating the `sed` commands to use more robust patterns for matching and replacing escape sequences.

Improvements to escape sequence handling:

* [`rofi-calendar/rofi-calendar`](diffhunk://#diff-b6a4dc5f5e5c7d99ad24902b83f71a0082e1eb90c9d6d57f9ac5663b1a3e5d8bL29-R30): Updated `sed` commands in the `print_month()` function to use more generalized regular expressions for matching ANSI escape sequences. This ensures better compatibility and correctness in formatting calendar output.