### PR TITLE
batterybar: replace egrep with grep -E

### DIFF
--- a/batterybar/batterybar
+++ b/batterybar/batterybar
@@ -25,8 +25,8 @@ battery_count=${#output[@]}
 for line in "${output[@]}";
 do
     percentages+=($(echo "$line" | grep -o -m1 '[0-9]\{1,3\}%' | tr -d '%'))
-    statuses+=($(echo "$line" | egrep -o -m1 'Discharging|Charging|AC|Full|Unknown'))
-    remaining=$(echo "$line" | egrep -o -m1 '[0-9][0-9]:[0-9][0-9]')
+    statuses+=($(echo "$line" | grep -E -o -m1 'Discharging|Charging|AC|Full|Unknown'))
+    remaining=$(echo "$line" | grep -E -o -m1 '[0-9][0-9]:[0-9][0-9]')
     if [[ -n $remaining ]]; then
         remainings+=(" ($remaining)")
     else 


### PR DESCRIPTION
Running `egrep` now produces a warning about its obsolescence. This commit replaces `egrep` with `grep -E` to get rid of the warning.